### PR TITLE
fix: remove ALTER TABLE on storage.objects (permission error)

### DIFF
--- a/supabase/migrations/20251204210620_setup_disc_photos_storage.sql
+++ b/supabase/migrations/20251204210620_setup_disc_photos_storage.sql
@@ -9,8 +9,8 @@ VALUES (
 )
 ON CONFLICT (id) DO NOTHING;
 
--- Enable RLS on storage.objects
-ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
+-- Note: RLS is already enabled on storage.objects by default in Supabase
+-- No need to enable it manually
 
 -- Policy: Users can upload photos to their own folder
 -- Path structure: {user_id}/{disc_id}/{photo_type}.jpg


### PR DESCRIPTION
## Problem
Migration failed with permission error:
```
ERROR: must be owner of table objects (SQLSTATE 42501)
At statement: ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY
```

## Root Cause
`storage.objects` is a Supabase system table that:
- Already has RLS enabled by default
- We don't have permission to alter it
- We don't need to alter it

## Solution
Removed the `ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY` statement.

Added comment explaining that RLS is already enabled by default.

## Impact
- ✅ Migration will now succeed
- ✅ RLS policies still work correctly (they don't require explicit RLS enablement)
- ✅ No functional changes to storage bucket or policies

## Testing
Migration will be automatically applied on merge.