### PR TITLE
fix: remove policy comments (permission denied)

### DIFF
--- a/supabase/migrations/20251204210620_setup_disc_photos_storage.sql
+++ b/supabase/migrations/20251204210620_setup_disc_photos_storage.sql
@@ -65,12 +65,5 @@ USING (
 -- TODO: Add policy for finders to read photos of discs in active recovery events
 -- This will be implemented when recovery events feature is added
 
--- Add comments
-COMMENT ON POLICY "Users can upload own disc photos" ON storage.objects IS
-  'Users can upload photos to their own folder with path: {user_id}/{disc_id}/{photo_type}';
-COMMENT ON POLICY "Users can read own disc photos" ON storage.objects IS
-  'Users can read photos from their own folder';
-COMMENT ON POLICY "Users can update own disc photos" ON storage.objects IS
-  'Users can update photos in their own folder';
-COMMENT ON POLICY "Users can delete own disc photos" ON storage.objects IS
-  'Users can delete photos from their own folder';
+-- Note: Cannot add comments to storage.objects policies (system table, permission denied)
+-- Policy descriptions are in the SQL comments above each policy


### PR DESCRIPTION
## Problem
Migration failed with:
```
ERROR: must be owner of relation objects (SQLSTATE 42501)
At statement: COMMENT ON POLICY ... ON storage.objects
```

## Solution
Removed all `COMMENT ON POLICY` statements for storage.objects policies.

Policy descriptions remain in SQL comments above each policy.

## Final Migration
Now only contains operations we have permission for:
- ✅ INSERT INTO storage.buckets
- ✅ CREATE POLICY on storage.objects
- ✅ SQL comments (documentation only)

No system table alterations:
- ❌ ALTER TABLE storage.objects (removed in PR #25)
- ❌ COMMENT ON POLICY (removed in this PR)

Migration should now succeed.