### PR TITLE
feat: add migration validation to PR workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,28 @@ jobs:
             echo "No edge functions to check"
           fi
 
+  validate-migrations:
+    name: Validate Database Migrations
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Validate migrations (dry-run)
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+        run: |
+          supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+          supabase db push --dry-run
+
   migrate:
     name: Run Database Migrations
     needs: [test, check-edge-functions]


### PR DESCRIPTION
## Problem
We've been creating multiple fix PRs because migrations fail after merge:
- PR #24: Initial storage setup
- PR #25: Fix ALTER TABLE permission
- PR #26: Fix COMMENT ON POLICY permission

Each error was only caught AFTER merging to main.

## Solution
Add **validate-migrations** job that runs on PRs:

### New Workflow
```yaml
validate-migrations:
  - Runs on: pull_request only (not main)
  - Command: supabase db push --dry-run
  - Catches: SQL errors, permission issues, syntax problems
  - Result: ✅ or ❌ in PR checks
```

### Benefits
- 🚫 No more broken migrations reaching main
- ⚡ Fast feedback in PR (catches errors before merge)
- 🔍 Same validation as production (uses actual database)
- 🎯 Only validates, doesn't apply changes

### Example
Before: ❌ Merge → Fail → Fix PR → Repeat
After: ✅ PR Check Fails → Fix → PR Check Passes → Merge

## Testing
This PR itself will test the new validation job!

We can also test with PR #26 to see if it catches any remaining issues.

## Note
This requires the same secrets as the migrate job:
- SUPABASE_ACCESS_TOKEN
- SUPABASE_DB_PASSWORD  
- SUPABASE_PROJECT_REF

(Already configured)