### PR TITLE
fix: remove name field requirement, use mold as primary identifier

### DIFF
--- a/supabase/functions/create-disc/index.test.ts
+++ b/supabase/functions/create-disc/index.test.ts
@@ -13,13 +13,13 @@ Deno.test('create-disc: should return 401 when not authenticated', async () => {
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ name: 'Test Disc' }),
+    body: JSON.stringify({ mold: 'Test Disc' }),
   });
 
   assertEquals(response.status, 401);
 });
 
-Deno.test('create-disc: should return 400 when name is missing', async () => {
+Deno.test('create-disc: should return 400 when mold is missing', async () => {
   const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
   // Sign up a test user
@@ -40,6 +40,7 @@ Deno.test('create-disc: should return 400 when name is missing', async () => {
   assertEquals(response.status, 400);
   const error = await response.json();
   assertExists(error.error);
+  assertEquals(error.error, 'Mold is required');
 });
 
 Deno.test('create-disc: should create disc with minimal data', async () => {
@@ -58,7 +59,7 @@ Deno.test('create-disc: should create disc with minimal data', async () => {
       Authorization: `Bearer ${authData.session?.access_token}`,
     },
     body: JSON.stringify({
-      name: 'Test Disc',
+      mold: 'Destroyer',
       flight_numbers: { speed: 7, glide: 5, turn: 0, fade: 1 },
     }),
   });
@@ -66,7 +67,8 @@ Deno.test('create-disc: should create disc with minimal data', async () => {
   assertEquals(response.status, 201);
   const data = await response.json();
   assertExists(data.id);
-  assertEquals(data.name, 'Test Disc');
+  assertEquals(data.name, 'Destroyer'); // name should be set to mold
+  assertEquals(data.mold, 'Destroyer');
   assertEquals(data.owner_id, authData.user?.id);
 });
 
@@ -80,9 +82,8 @@ Deno.test('create-disc: should create disc with all fields', async () => {
   });
 
   const discData = {
-    name: 'Innova Destroyer',
-    manufacturer: 'Innova',
     mold: 'Destroyer',
+    manufacturer: 'Innova',
     plastic: 'Star',
     weight: 175,
     color: 'Blue',
@@ -103,7 +104,7 @@ Deno.test('create-disc: should create disc with all fields', async () => {
   assertEquals(response.status, 201);
   const data = await response.json();
   assertExists(data.id);
-  assertEquals(data.name, discData.name);
+  assertEquals(data.name, discData.mold); // name should be set to mold
   assertEquals(data.manufacturer, discData.manufacturer);
   assertEquals(data.mold, discData.mold);
   assertEquals(data.plastic, discData.plastic);
@@ -130,7 +131,7 @@ Deno.test('create-disc: should validate flight numbers', async () => {
       Authorization: `Bearer ${authData.session?.access_token}`,
     },
     body: JSON.stringify({
-      name: 'Test Disc',
+      mold: 'Destroyer',
       flight_numbers: { speed: 20, glide: 5, turn: 0, fade: 1 }, // Invalid speed
     }),
   });

--- a/supabase/functions/create-disc/index.ts
+++ b/supabase/functions/create-disc/index.ts
@@ -10,9 +10,8 @@ interface FlightNumbers {
 }
 
 interface CreateDiscRequest {
-  name: string;
   manufacturer?: string;
-  mold?: string;
+  mold: string;
   plastic?: string;
   weight?: number;
   color?: string;
@@ -89,8 +88,8 @@ Deno.serve(async (req) => {
   }
 
   // Validate required fields
-  if (!body.name || body.name.trim() === '') {
-    return new Response(JSON.stringify({ error: 'Name is required' }), {
+  if (!body.mold || body.mold.trim() === '') {
+    return new Response(JSON.stringify({ error: 'Mold is required' }), {
       status: 400,
       headers: { 'Content-Type': 'application/json' },
     });
@@ -112,12 +111,12 @@ Deno.serve(async (req) => {
     });
   }
 
-  // Create disc
+  // Create disc (use mold as name)
   const { data: disc, error: dbError } = await supabase
     .from('discs')
     .insert({
       owner_id: user.id,
-      name: body.name,
+      name: body.mold, // Use mold as the disc name
       manufacturer: body.manufacturer,
       mold: body.mold,
       plastic: body.plastic,


### PR DESCRIPTION
## Summary

Removes the `name` field requirement from the create-disc API and makes `mold` the primary required field. The API now auto-sets the database `name` field to the `mold` value.

**Related Issue:** Fixes mobile app integration issue

## Changes

**API Interface:**
- `name` removed from CreateDiscRequest interface
- `mold` is now required (was optional)
- Database `name` field is auto-populated with mold value

**Validation:**
- Changed validation from "Name is required" to "Mold is required"
- Updated error messages accordingly

**Tests:**
- Updated all test cases to use `mold` instead of `name`
- Verified name field is set to mold value in responses
- All tests passing with new structure

## Why This Change?

The mobile app UX uses "Mold" as the primary identifier (e.g., "Destroyer", "Buzzz"), not a custom name. This aligns the API with the mobile app's data model while maintaining database compatibility by auto-setting name=mold.

## Migration Impact

✅ **Backward Compatible** - Existing records unaffected
⚠️ **Breaking Change** - Clients must now send `mold` (required) instead of `name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)