### PR TITLE
feat: add automatic edge function deployment on merge to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,8 +84,29 @@ jobs:
           supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
           supabase db push
 
+  deploy-functions:
+    name: Deploy Edge Functions
+    needs: [test, check-edge-functions]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Deploy edge functions
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        run: |
+          supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
+          supabase functions deploy --no-verify-jwt
+
   release:
-    needs: migrate
+    needs: [migrate, deploy-functions]
     uses: 'appdiscr/.github/.github/workflows/release.yml@main'
     secrets: inherit
     permissions:


### PR DESCRIPTION
## Summary

Adds automatic deployment of edge functions when code is merged to main. Previously, only database migrations were deployed automatically - edge functions had to be deployed manually.

## Changes

**New CI/CD Job: `deploy-functions`**
- Runs on push to main (same trigger as migrations)
- Runs in parallel with `migrate` job for faster deployment
- Uses `supabase functions deploy --no-verify-jwt` to deploy all functions
- Requires `SUPABASE_ACCESS_TOKEN` secret (already configured)

**Workflow Dependencies:**
```
test → check-edge-functions → deploy-functions → release
                           ↘ migrate         ↗
```

## Why This Change?

Currently, when edge function code is merged to main:
- ✅ Migrations are deployed automatically
- ❌ Edge functions are NOT deployed (manual deployment required)

This creates a gap where the database schema is updated but the function code is not, causing runtime errors like "function not found".

## Testing

After merging, verify:
1. Push to main triggers `deploy-functions` job
2. All edge functions are deployed successfully  
3. Functions are accessible immediately after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)