### PR TITLE
feat: support flexible photo types (photo-1 through photo-4)

### DIFF
--- a/supabase/functions/upload-disc-photo/index.ts
+++ b/supabase/functions/upload-disc-photo/index.ts
@@ -3,7 +3,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
 const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
-const VALID_PHOTO_TYPES = ['top', 'bottom', 'side'];
+const VALID_PHOTO_TYPES = ['photo-1', 'photo-2', 'photo-3', 'photo-4'];
 
 Deno.serve(async (req) => {
   // Only allow POST requests
@@ -69,7 +69,7 @@ Deno.serve(async (req) => {
   }
 
   if (!photoType || !VALID_PHOTO_TYPES.includes(photoType)) {
-    return new Response(JSON.stringify({ error: 'photo_type must be one of: top, bottom, side' }), {
+    return new Response(JSON.stringify({ error: 'photo_type must be one of: photo-1, photo-2, photo-3, photo-4' }), {
       status: 400,
       headers: { 'Content-Type': 'application/json' },
     });


### PR DESCRIPTION
## Summary

Updates the upload-disc-photo endpoint to support flexible photo slots instead of fixed view types:

- **Old**: `photo_type` must be `top`, `bottom`, or `side` (3 specific views)
- **New**: `photo_type` must be `photo-1`, `photo-2`, `photo-3`, or `photo-4` (4 flexible slots)

This allows users to upload 1-4 photos per disc without requiring specific photo types.

## Technical Details

- Updated `VALID_PHOTO_TYPES` array in upload-disc-photo/index.ts:6
- Updated error message for invalid photo types at line 72
- No database schema changes required (photo_type is a string column)
- Backwards compatible: existing photos with old types remain valid

## Files Changed

- `supabase/functions/upload-disc-photo/index.ts`

## Related PRs

- Mobile PR #28: Implements photo upload UI using these new photo types

## Test Plan

- [ ] Upload photo with type `photo-1` (should succeed)
- [ ] Upload photo with type `photo-4` (should succeed)
- [ ] Upload photo with type `top` (should fail with updated error message)
- [ ] Verify error message lists all 4 valid types

🤖 Generated with [Claude Code](https://claude.com/claude-code)