### PR TITLE
fix: add missing photo_type migrations to sync with database

### DIFF
--- a/supabase/migrations/20251205032123_update_photo_type_enum.sql
+++ b/supabase/migrations/20251205032123_update_photo_type_enum.sql
@@ -1,0 +1,12 @@
+-- Update photo_type enum to support flexible photo slots instead of fixed view types
+-- Old values: 'top', 'bottom', 'side'
+-- New values: 'photo-1', 'photo-2', 'photo-3', 'photo-4'
+
+-- Add new enum values
+ALTER TYPE photo_type ADD VALUE IF NOT EXISTS 'photo-1';
+ALTER TYPE photo_type ADD VALUE IF NOT EXISTS 'photo-2';
+ALTER TYPE photo_type ADD VALUE IF NOT EXISTS 'photo-3';
+ALTER TYPE photo_type ADD VALUE IF NOT EXISTS 'photo-4';
+
+-- Note: We keep the old values (top, bottom, side) for backward compatibility
+-- They can be removed in a future migration if needed

--- a/supabase/migrations/20251205042607_change_photo_type_to_text.sql
+++ b/supabase/migrations/20251205042607_change_photo_type_to_text.sql
@@ -1,0 +1,7 @@
+-- Change photo_type column from enum to text to support UUID-based filenames
+-- This allows storing unique photo IDs instead of fixed photo-1, photo-2, etc.
+
+ALTER TABLE disc_photos ALTER COLUMN photo_type TYPE text;
+
+-- Drop the old enum type if it exists and is no longer used
+DROP TYPE IF EXISTS photo_type_enum CASCADE;


### PR DESCRIPTION
## Summary
These migrations were applied to the database but never merged to main, causing CI failures for new PRs.

- `20251205032123_update_photo_type_enum.sql` - Add photo-1 through photo-4 enum values
- `20251205042607_change_photo_type_to_text.sql` - Change photo_type from enum to text

## Test plan
- [ ] CI passes (migrations already applied to database)
- [ ] Unblocks other PRs waiting on migration sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)