### PR TITLE
fix: use UUID-based photo filenames instead of photo_type

### DIFF
--- a/docs/DATABASE_SCHEMA.md
+++ b/docs/DATABASE_SCHEMA.md
@@ -101,12 +101,10 @@ Photos of discs for identification.
   id: uuid PRIMARY KEY DEFAULT gen_random_uuid()
   disc_id: uuid REFERENCES discs(id) ON DELETE CASCADE NOT NULL
   storage_path: text NOT NULL
-  photo_type: photo_type DEFAULT 'top' NOT NULL
+  photo_uuid: text NOT NULL  // UUID identifier for the photo file
   created_at: timestamp with time zone DEFAULT now() NOT NULL
 }
 ```
-
-**Photo Type Enum:** `top`, `bottom`, `side`
 
 #### recovery_events
 

--- a/src/schema/disc-photos.test.ts
+++ b/src/schema/disc-photos.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { discPhotos, PhotoType } from './disc-photos';
+import { discPhotos } from './disc-photos';
 import { getTableColumns, getTableName } from 'drizzle-orm';
 
 describe('disc_photos schema', () => {
@@ -14,7 +14,7 @@ describe('disc_photos schema', () => {
     expect(columnNames).toContain('id');
     expect(columnNames).toContain('disc_id');
     expect(columnNames).toContain('storage_path');
-    expect(columnNames).toContain('photo_type');
+    expect(columnNames).toContain('photo_uuid');
     expect(columnNames).toContain('created_at');
   });
 
@@ -37,21 +37,15 @@ describe('disc_photos schema', () => {
     expect(columns.storage_path.notNull).toBe(true);
   });
 
-  it('should have photo_type as enum with default', () => {
+  it('should have photo_uuid as text and required', () => {
     const columns = getTableColumns(discPhotos);
-    expect(columns.photo_type.enumValues).toEqual(['top', 'bottom', 'side']);
-    expect(columns.photo_type.notNull).toBe(true);
+    expect(columns.photo_uuid.dataType).toBe('string');
+    expect(columns.photo_uuid.notNull).toBe(true);
   });
 
   it('should have created_at as timestamp with default', () => {
     const columns = getTableColumns(discPhotos);
     expect(columns.created_at.dataType).toBe('date');
     expect(columns.created_at.notNull).toBe(true);
-  });
-
-  it('should export PhotoType enum values', () => {
-    expect(PhotoType.TOP).toBe('top');
-    expect(PhotoType.BOTTOM).toBe('bottom');
-    expect(PhotoType.SIDE).toBe('side');
   });
 });

--- a/src/schema/disc-photos.ts
+++ b/src/schema/disc-photos.ts
@@ -1,14 +1,6 @@
-import { pgTable, text, timestamp, uuid, pgEnum } from 'drizzle-orm/pg-core';
+import { pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
 import { discs } from './discs';
-
-export const photoTypeEnum = pgEnum('photo_type', ['top', 'bottom', 'side']);
-
-export const PhotoType = {
-  TOP: 'top',
-  BOTTOM: 'bottom',
-  SIDE: 'side',
-} as const;
 
 export const discPhotos = pgTable('disc_photos', {
   id: uuid('id')
@@ -19,7 +11,7 @@ export const discPhotos = pgTable('disc_photos', {
     .references(() => discs.id, { onDelete: 'cascade' })
     .notNull(),
   storage_path: text('storage_path').notNull(),
-  photo_type: photoTypeEnum('photo_type').notNull().default('top'),
+  photo_uuid: text('photo_uuid').notNull(),
   created_at: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
 });
 

--- a/src/schema/schema-types.test.ts
+++ b/src/schema/schema-types.test.ts
@@ -80,12 +80,12 @@ describe('schema type inference', () => {
       id: '123e4567-e89b-12d3-a456-426614174000',
       disc_id: '123e4567-e89b-12d3-a456-426614174000',
       storage_path: '/photos/disc123.jpg',
-      photo_type: 'top',
+      photo_uuid: '550e8400-e29b-41d4-a716-446655440000',
       created_at: new Date(),
     };
 
     expect(newDiscPhoto.storage_path).toBe('/photos/disc123.jpg');
-    expect(discPhoto.photo_type).toBe('top');
+    expect(discPhoto.photo_uuid).toBe('550e8400-e29b-41d4-a716-446655440000');
   });
 
   it('should infer RecoveryEvent types correctly', () => {

--- a/supabase/functions/get-user-discs/index.test.ts
+++ b/supabase/functions/get-user-discs/index.test.ts
@@ -69,10 +69,10 @@ Deno.test('get-user-discs: should return user discs with photos', async () => {
     .select()
     .single();
 
-  // Add photos to first disc
+  // Add photos to first disc (photo_uuid is a UUID identifier)
   await supabaseAuth.from('disc_photos').insert([
-    { disc_id: disc1.id, storage_path: 'test/path/top.jpg', photo_type: 'top' },
-    { disc_id: disc1.id, storage_path: 'test/path/bottom.jpg', photo_type: 'bottom' },
+    { disc_id: disc1.id, storage_path: 'test/path/photo1.jpg', photo_uuid: crypto.randomUUID() },
+    { disc_id: disc1.id, storage_path: 'test/path/photo2.jpg', photo_uuid: crypto.randomUUID() },
   ]);
 
   const response = await fetch(FUNCTION_URL, {

--- a/supabase/functions/get-user-discs/index.ts
+++ b/supabase/functions/get-user-discs/index.ts
@@ -46,7 +46,7 @@ Deno.serve(async (req) => {
     .select(
       `
       *,
-      photos:disc_photos(id, storage_path, photo_type, created_at)
+      photos:disc_photos(id, storage_path, photo_uuid, created_at)
     `
     )
     .eq('owner_id', user.id)
@@ -65,7 +65,7 @@ Deno.serve(async (req) => {
     (discs || []).map(async (disc) => {
       const photosWithUrls = await Promise.all(
         (disc.photos || []).map(
-          async (photo: { id: string; storage_path: string; photo_type: string; created_at: string }) => {
+          async (photo: { id: string; storage_path: string; photo_uuid: string; created_at: string }) => {
             const { data: urlData } = await supabase.storage
               .from('disc-photos')
               .createSignedUrl(photo.storage_path, 3600); // 1 hour expiry

--- a/supabase/migrations/20251206030426_rename_photo_type_to_photo_uuid.sql
+++ b/supabase/migrations/20251206030426_rename_photo_type_to_photo_uuid.sql
@@ -1,0 +1,3 @@
+-- Rename photo_type column to photo_uuid for clarity
+-- The column now stores UUID identifiers instead of type labels
+ALTER TABLE disc_photos RENAME COLUMN photo_type TO photo_uuid;


### PR DESCRIPTION
## Summary
- Rename `photo_type` column to `photo_uuid` for clarity
- Generate UUID server-side for each photo upload (no more photo-1, photo-2, etc.)
- Remove `photo_type` parameter requirement from upload-disc-photo API
- Add photo count limit (max 4 per disc) enforcement server-side
- Update Drizzle schema and tests to reflect column rename
- Update get-user-discs to return `photo_uuid`

## Test plan
- [ ] Run API tests locally
- [ ] Test photo upload from mobile app
- [ ] Verify photos display correctly in disc list and detail views

🤖 Generated with [Claude Code](https://claude.com/claude-code)