### PR TITLE
fix: cast disc relation through unknown for proper type assertion

### DIFF
--- a/supabase/functions/get-my-finds/index.ts
+++ b/supabase/functions/get-my-finds/index.ts
@@ -96,7 +96,8 @@ Deno.serve(async (req) => {
   const recoveriesWithDetails = await Promise.all(
     (recoveries || []).map(async (recovery) => {
       // Extract disc (Supabase returns single object for foreign key relations)
-      const disc = recovery.disc as {
+      // Cast through unknown since TypeScript incorrectly infers this as an array
+      const disc = recovery.disc as unknown as {
         id: string;
         name: string;
         manufacturer: string;


### PR DESCRIPTION
## Summary

- Fix TypeScript error in get-my-finds edge function
- Cast through `unknown` first since TypeScript incorrectly infers foreign key joins as arrays

## Test plan

- [ ] Verify type check passes in CI
- [ ] Verify edge function deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)