### PR TITLE
chore(deps): bump actions/checkout to v6 and setup-deno to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,10 +25,10 @@ jobs:
     # - Run: deno test --allow-all supabase/functions/**/index.test.ts
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
           deno-version: v1.x
 
@@ -48,7 +48,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
@@ -70,7 +70,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
@@ -92,7 +92,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1


### PR DESCRIPTION
## Summary
- Update `actions/checkout` from v4 to v6
- Update `denoland/setup-deno` from v1 to v2 (keeping `deno-version` at v1.x since Supabase Edge Functions still run on Deno 1.x runtime)

Replaces the closed Dependabot PRs #63 and #64.

## Test plan
- [ ] Verify CI checks pass
- [ ] Merge and verify subsequent PRs work

🤖 Generated with [Claude Code](https://claude.com/claude-code)