### PR TITLE
fix: handle disc relation as object or array in propose-meetup

### DIFF
--- a/supabase/functions/propose-meetup/index.ts
+++ b/supabase/functions/propose-meetup/index.ts
@@ -124,7 +124,10 @@ Deno.serve(async (req) => {
   }
 
   // Check if user is a participant (owner or finder)
-  const discOwner = (recoveryEvent.disc as { owner_id: string }[] | null)?.[0]?.owner_id;
+  // Handle both array and object responses for disc relation
+  const discData = recoveryEvent.disc as { owner_id: string } | { owner_id: string }[] | null;
+  const disc = Array.isArray(discData) ? discData[0] : discData;
+  const discOwner = disc?.owner_id;
   const isOwner = discOwner === user.id;
   const isFinder = recoveryEvent.finder_id === user.id;
 


### PR DESCRIPTION
## Summary
Fix the "You are not a participant in this recovery" error when owner tries to propose a meetup.

Supabase may return the disc relation as an object or array depending on the query context. This fix handles both cases when checking if the user is the disc owner.

## Test plan
- [ ] As owner, try to propose a meetup - should now work
- [ ] As finder, propose a meetup - should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)