### PR TITLE
fix: update RLS policies for ownership transfer

### DIFF
--- a/supabase/migrations/20251208143806_fix_rls_for_ownership_transfer.sql
+++ b/supabase/migrations/20251208143806_fix_rls_for_ownership_transfer.sql
@@ -1,0 +1,57 @@
+-- Fix RLS policies to handle ownership transfers
+-- After a disc is surrendered, the original owner should still be able to view
+-- the recovery event they were part of, and the new owner needs access to photos.
+
+-- Allow original owners to view recovery events where they were the original owner
+CREATE POLICY "Original owners can view surrendered recovery events"
+  ON "public"."recovery_events"
+  FOR SELECT
+  USING (original_owner_id = auth.uid());
+
+-- Allow disc photos to be viewed by anyone who was involved in a recovery for that disc
+-- This covers: current owner, finders, and original owners after surrender
+DROP POLICY IF EXISTS "Users can read photos of own discs" ON "public"."disc_photos";
+
+CREATE POLICY "Users can read photos of discs they own or are recovering"
+  ON "public"."disc_photos"
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM "public"."discs"
+      WHERE "discs"."id" = "disc_photos"."disc_id"
+      AND "discs"."owner_id" = auth.uid()
+    )
+    OR EXISTS (
+      SELECT 1 FROM "public"."recovery_events" re
+      JOIN "public"."discs" d ON d.id = re.disc_id
+      WHERE d.id = "disc_photos"."disc_id"
+      AND (re.finder_id = auth.uid() OR re.original_owner_id = auth.uid())
+    )
+  );
+
+-- Allow new owners to insert/delete photos for their discs
+-- (existing policies already handle this since they check current owner_id)
+
+-- Fix storage bucket policy for disc photos
+-- The original policy only allowed reading files in folders matching the user's ID
+-- After ownership transfer, the new owner needs to read files in the original owner's folder
+DROP POLICY IF EXISTS "Users can read own disc photos" ON storage.objects;
+
+CREATE POLICY "Users can read disc photos they own"
+ON storage.objects
+FOR SELECT
+TO authenticated
+USING (
+  bucket_id = 'disc-photos' AND
+  (
+    -- Original behavior: user can read their own folder
+    (storage.foldername(name))[1] = auth.uid()::text
+    OR
+    -- New: current disc owner can read photos regardless of folder
+    EXISTS (
+      SELECT 1 FROM public.discs
+      WHERE discs.id::text = (storage.foldername(name))[2]
+      AND discs.owner_id = auth.uid()
+    )
+  )
+);


### PR DESCRIPTION
## Summary
Fixes RLS policies to properly handle ownership transfers after disc surrender.

## Issues Fixed
1. **Original owner loses access to recovery event** - After surrendering, the original owner couldn't view the recovery event anymore because RLS checked `discs.owner_id` which now points to the finder
2. **New owner can't see disc photos** - The `disc_photos` RLS policy only allowed the current owner to see photos, but didn't account for ownership transfers

## Changes
- Add policy allowing original owners to view recovery events where `original_owner_id = auth.uid()`
- Update disc photos policy to allow viewing by:
  - Current disc owner
  - Finders involved in recovery events for that disc  
  - Original owners after surrender

## Test plan
- [ ] Verify original owner can still view recovery event after surrender
- [ ] Verify new owner (finder) can see disc photos after surrender
- [ ] Verify original owner can still see disc photos in recovery context

🤖 Generated with [Claude Code](https://claude.com/claude-code)