### PR TITLE
refactor: store disc photos under disc_id instead of owner_id

### DIFF
--- a/supabase/functions/delete-disc-photo/index.ts
+++ b/supabase/functions/delete-disc-photo/index.ts
@@ -1,0 +1,116 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+interface DeletePhotoRequest {
+  photo_id: string;
+}
+
+Deno.serve(async (req) => {
+  // Only allow DELETE requests
+  if (req.method !== 'DELETE') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Check authentication
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) {
+    return new Response(JSON.stringify({ error: 'Missing authorization header' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Create Supabase client
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+  const supabaseKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
+  const supabase = createClient(supabaseUrl, supabaseKey, {
+    global: {
+      headers: { Authorization: authHeader },
+    },
+  });
+
+  // Verify user is authenticated
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Parse request body
+  let body: DeletePhotoRequest;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Validate required fields
+  if (!body.photo_id || body.photo_id.trim() === '') {
+    return new Response(JSON.stringify({ error: 'photo_id is required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Create service role client for privileged operations
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+  const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
+
+  // Get the photo record with disc info to verify ownership
+  const { data: photo, error: photoError } = await supabaseAdmin
+    .from('disc_photos')
+    .select('id, storage_path, disc_id, disc:discs(owner_id)')
+    .eq('id', body.photo_id)
+    .single();
+
+  if (photoError || !photo) {
+    return new Response(JSON.stringify({ error: 'Photo not found' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Verify user owns the disc
+  const discData = Array.isArray(photo.disc) ? photo.disc[0] : photo.disc;
+  if (!discData || discData.owner_id !== user.id) {
+    return new Response(JSON.stringify({ error: 'You do not own this disc' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Delete from storage
+  const { error: storageError } = await supabaseAdmin.storage.from('disc-photos').remove([photo.storage_path]);
+
+  if (storageError) {
+    console.error('Storage delete error:', storageError);
+    // Continue to delete DB record even if storage fails (file may not exist)
+  }
+
+  // Delete from database
+  const { error: dbError } = await supabaseAdmin.from('disc_photos').delete().eq('id', body.photo_id);
+
+  if (dbError) {
+    console.error('Database delete error:', dbError);
+    return new Response(JSON.stringify({ error: 'Failed to delete photo record', details: dbError.message }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  return new Response(JSON.stringify({ success: true, message: 'Photo deleted successfully' }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+});

--- a/supabase/functions/migrate-photo-storage/index.ts
+++ b/supabase/functions/migrate-photo-storage/index.ts
@@ -1,0 +1,141 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+/**
+ * One-time migration function to move photos from old structure to new structure.
+ *
+ * Old structure: {owner_id}/{disc_id}/{photo_uuid}.{ext}
+ * New structure: {disc_id}/{photo_uuid}.{ext}
+ *
+ * This function should be run once after the database migration.
+ * It requires service role key to access storage.
+ *
+ * POST /migrate-photo-storage
+ * Body: { dry_run?: boolean }
+ */
+
+Deno.serve(async (req) => {
+  // Only allow POST requests
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Check authentication - require service role or admin
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) {
+    return new Response(JSON.stringify({ error: 'Missing authorization header' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Parse request body
+  let dryRun = false;
+  try {
+    const body = await req.json();
+    dryRun = body.dry_run === true;
+  } catch {
+    // No body or invalid JSON, use defaults
+  }
+
+  // Create service role client
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+  const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+  // Get all photos that need migration (old path structure has 3 parts)
+  const { data: photos, error: fetchError } = await supabase
+    .from('disc_photos')
+    .select('id, disc_id, storage_path, photo_uuid');
+
+  if (fetchError) {
+    console.error('Error fetching photos:', fetchError);
+    return new Response(JSON.stringify({ error: 'Failed to fetch photos', details: fetchError.message }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const results = {
+    total: photos?.length || 0,
+    migrated: 0,
+    skipped: 0,
+    errors: [] as string[],
+    dryRun,
+  };
+
+  for (const photo of photos || []) {
+    const pathParts = photo.storage_path.split('/');
+
+    // Check if this is old format (3 parts: owner_id/disc_id/filename)
+    if (pathParts.length !== 3) {
+      // Already migrated or unexpected format
+      results.skipped++;
+      continue;
+    }
+
+    const [, discId, filename] = pathParts;
+    const newPath = `${discId}/${filename}`;
+
+    console.log(`Migrating: ${photo.storage_path} -> ${newPath}`);
+
+    if (dryRun) {
+      results.migrated++;
+      continue;
+    }
+
+    try {
+      // Download the file from old location
+      const { data: fileData, error: downloadError } = await supabase.storage
+        .from('disc-photos')
+        .download(photo.storage_path);
+
+      if (downloadError) {
+        console.error(`Error downloading ${photo.storage_path}:`, downloadError);
+        results.errors.push(`Download failed for ${photo.id}: ${downloadError.message}`);
+        continue;
+      }
+
+      // Upload to new location
+      const { error: uploadError } = await supabase.storage.from('disc-photos').upload(newPath, fileData, {
+        contentType: fileData.type || 'image/jpeg',
+        upsert: true,
+      });
+
+      if (uploadError) {
+        console.error(`Error uploading to ${newPath}:`, uploadError);
+        results.errors.push(`Upload failed for ${photo.id}: ${uploadError.message}`);
+        continue;
+      }
+
+      // Delete from old location
+      const { error: deleteError } = await supabase.storage.from('disc-photos').remove([photo.storage_path]);
+
+      if (deleteError) {
+        console.error(`Error deleting ${photo.storage_path}:`, deleteError);
+        // Don't fail - file is copied, just couldn't delete old one
+        results.errors.push(`Delete failed for ${photo.id}: ${deleteError.message} (file was copied)`);
+      }
+
+      results.migrated++;
+    } catch (err) {
+      console.error(`Unexpected error for ${photo.id}:`, err);
+      results.errors.push(`Unexpected error for ${photo.id}: ${err}`);
+    }
+  }
+
+  return new Response(
+    JSON.stringify({
+      success: true,
+      message: dryRun ? 'Dry run complete' : 'Migration complete',
+      results,
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
+});

--- a/supabase/functions/upload-disc-photo/index.ts
+++ b/supabase/functions/upload-disc-photo/index.ts
@@ -144,8 +144,8 @@ Deno.serve(async (req) => {
   const extension = file.type === 'image/jpeg' ? 'jpg' : file.type === 'image/png' ? 'png' : 'webp';
 
   // Upload file to storage
-  // Path: {user_id}/{disc_id}/{uuid}.{extension}
-  const storagePath = `${user.id}/${discId}/${photoId}.${extension}`;
+  // Path: {disc_id}/{uuid}.{extension}
+  const storagePath = `${discId}/${photoId}.${extension}`;
 
   const { error: uploadError } = await supabaseAdmin.storage.from('disc-photos').upload(storagePath, file, {
     contentType: file.type,

--- a/supabase/migrations/20251208154017_refactor_photo_storage_by_disc_id.sql
+++ b/supabase/migrations/20251208154017_refactor_photo_storage_by_disc_id.sql
@@ -1,0 +1,103 @@
+-- Refactor photo storage to use disc_id instead of owner_id in path
+-- New structure: {disc_id}/{photo_uuid}.{ext}
+-- Old structure: {owner_id}/{disc_id}/{photo_uuid}.{ext}
+
+-- Step 1: Create a function to migrate photos in storage
+-- Note: This migration updates the database records. The actual file moves
+-- need to be done via a separate script using the Supabase Storage API,
+-- as SQL cannot directly move files in storage buckets.
+
+-- Update all disc_photos records to use new path structure
+-- Extract disc_id and filename from old path and create new path
+UPDATE disc_photos
+SET storage_path = CONCAT(
+  disc_id::text,
+  '/',
+  SUBSTRING(storage_path FROM '[^/]+$')  -- Get just the filename
+)
+WHERE storage_path LIKE '%/%/%';  -- Only update paths with old structure
+
+-- Step 2: Drop old storage policies
+DROP POLICY IF EXISTS "Users can upload own disc photos" ON storage.objects;
+DROP POLICY IF EXISTS "Users can read own disc photos" ON storage.objects;
+DROP POLICY IF EXISTS "Users can read disc photos they own" ON storage.objects;
+DROP POLICY IF EXISTS "Users can update own disc photos" ON storage.objects;
+DROP POLICY IF EXISTS "Users can delete own disc photos" ON storage.objects;
+
+-- Step 3: Create new simplified storage policies
+-- New path structure: {disc_id}/{filename}
+
+-- Policy: Users can upload photos to discs they own
+-- Path structure: {disc_id}/{photo_uuid}.{ext}
+CREATE POLICY "Users can upload photos to own discs"
+ON storage.objects
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  bucket_id = 'disc-photos' AND
+  EXISTS (
+    SELECT 1 FROM public.discs
+    WHERE discs.id::text = (storage.foldername(name))[1]
+    AND discs.owner_id = auth.uid()
+  )
+);
+
+-- Policy: Users can read photos of discs they own or are involved in recovery
+CREATE POLICY "Users can read disc photos"
+ON storage.objects
+FOR SELECT
+TO authenticated
+USING (
+  bucket_id = 'disc-photos' AND
+  (
+    -- Disc owner can read
+    EXISTS (
+      SELECT 1 FROM public.discs
+      WHERE discs.id::text = (storage.foldername(name))[1]
+      AND discs.owner_id = auth.uid()
+    )
+    OR
+    -- Finder or original owner in recovery can read
+    EXISTS (
+      SELECT 1 FROM public.recovery_events re
+      WHERE re.disc_id::text = (storage.foldername(name))[1]
+      AND (re.finder_id = auth.uid() OR re.original_owner_id = auth.uid())
+    )
+  )
+);
+
+-- Policy: Users can update photos of discs they own
+CREATE POLICY "Users can update photos of own discs"
+ON storage.objects
+FOR UPDATE
+TO authenticated
+USING (
+  bucket_id = 'disc-photos' AND
+  EXISTS (
+    SELECT 1 FROM public.discs
+    WHERE discs.id::text = (storage.foldername(name))[1]
+    AND discs.owner_id = auth.uid()
+  )
+)
+WITH CHECK (
+  bucket_id = 'disc-photos' AND
+  EXISTS (
+    SELECT 1 FROM public.discs
+    WHERE discs.id::text = (storage.foldername(name))[1]
+    AND discs.owner_id = auth.uid()
+  )
+);
+
+-- Policy: Users can delete photos of discs they own
+CREATE POLICY "Users can delete photos of own discs"
+ON storage.objects
+FOR DELETE
+TO authenticated
+USING (
+  bucket_id = 'disc-photos' AND
+  EXISTS (
+    SELECT 1 FROM public.discs
+    WHERE discs.id::text = (storage.foldername(name))[1]
+    AND discs.owner_id = auth.uid()
+  )
+);


### PR DESCRIPTION
## Summary

Refactors photo storage to use a simpler path structure based on disc_id rather than owner_id. This eliminates complexity around ownership transfers.

**Old structure:** `{owner_id}/{disc_id}/{photo_uuid}.{ext}`
**New structure:** `{disc_id}/{photo_uuid}.{ext}`

Closes #76

## Changes

### Edge Functions
- **`upload-disc-photo`**: Updated to use `{disc_id}/{filename}` path
- **`delete-disc-photo`**: New endpoint for deleting individual photos
- **`migrate-photo-storage`**: One-time migration function to move existing files

### Database Migration
- Updates all `disc_photos.storage_path` values to new format
- Drops old storage RLS policies
- Creates new simplified policies based on disc ownership

### Storage RLS Policies
- **INSERT**: User must own the disc
- **SELECT**: User owns disc OR is finder/original owner in recovery
- **UPDATE/DELETE**: User must own the disc

## Migration Steps

After deploying:
1. Run the database migration (automatic with `supabase db push`)
2. Deploy the `migrate-photo-storage` function
3. Call `POST /migrate-photo-storage` with `{"dry_run": true}` to preview
4. Call `POST /migrate-photo-storage` with `{"dry_run": false}` to execute
5. Verify photos are accessible
6. Optionally delete the `migrate-photo-storage` function after migration

## Test plan
- [ ] Test new photo upload uses correct path
- [ ] Test photo deletion works
- [ ] Run migration in dry_run mode
- [ ] Execute actual migration
- [ ] Verify existing photos still accessible after migration
- [ ] Test ownership transfer doesn't break photo access

🤖 Generated with [Claude Code](https://claude.com/claude-code)