### PR TITLE
chore: add Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "timezone": "America/Denver",
+  "schedule": ["after 10pm every weekday", "before 5am every weekday", "every weekend"],
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "Renovate Dependency Dashboard",
+  "semanticCommits": "enabled",
+  "commitMessagePrefix": "chore(deps):",
+  "commitMessageAction": "update",
+  "commitMessageExtra": "to {{newValue}}",
+  "commitMessageTopic": "{{depName}}",
+  "automerge": false,
+  "platformAutomerge": false,
+  "rebaseWhen": "behind-base-branch",
+  "labels": ["dependencies", "renovate"],
+  "assignees": ["@benniemosher"],
+  "vulnerabilityAlerts": {
+    "labels": ["security", "dependencies"],
+    "assignees": ["@benniemosher"]
+  },
+  "packageRules": [
+    {
+      "description": "Group Supabase packages",
+      "matchPackagePatterns": ["^@supabase/"],
+      "groupName": "supabase packages"
+    },
+    {
+      "description": "GitHub Actions - automerge patch/minor",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr"
+    },
+    {
+      "description": "Pre-commit hooks - group updates",
+      "matchManagers": ["pre-commit"],
+      "groupName": "pre-commit hooks"
+    },
+    {
+      "description": "Deno dependencies - group together",
+      "matchDatasources": ["deno"],
+      "groupName": "deno dependencies"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Add Renovate configuration for automated dependency updates via eikthyrnirbot.

## Configuration
- **Schedule**: Overnight on weekdays (10pm-5am) and weekends
- **Grouping**: 
  - Supabase packages
  - Deno dependencies
  - Pre-commit hooks
- **Automerge**: GitHub Actions minor/patch updates only
- **Assignee**: @benniemosher

## Next Steps
1. Install [eikthyrnirbot](https://github.com/apps/eikthyrnirbot) in acebackapp org
2. Disable Dependabot in org settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)