### PR TITLE
chore: add CI test workflow for PR validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,40 @@
+---
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Type check Deno functions
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Check Deno function types
+        run: deno check supabase/functions/**/*.ts


### PR DESCRIPTION
## Summary

Add GitHub Actions workflow to run tests and Deno type checks on PRs.

## Why

This enables Renovate PRs to be validated before merging. When package upgrades come in, the test suite will catch any regressions.

## What it does

- Runs `npm test` (vitest) on all PRs
- Runs `deno check` on edge functions to catch type errors

## Test plan

- [ ] CI workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)