### PR TITLE
fix: remove non-existent columns from get-my-finds query

### DIFF
--- a/supabase/functions/get-my-finds/index.ts
+++ b/supabase/functions/get-my-finds/index.ts
@@ -64,8 +64,6 @@ Deno.serve(async (req) => {
       id,
       status,
       finder_message,
-      meetup_location,
-      meetup_time,
       created_at,
       updated_at,
       disc:discs(
@@ -148,8 +146,6 @@ Deno.serve(async (req) => {
         id: recovery.id,
         status: recovery.status,
         finder_message: recovery.finder_message,
-        meetup_location: recovery.meetup_location,
-        meetup_time: recovery.meetup_time,
         created_at: recovery.created_at,
         updated_at: recovery.updated_at,
         disc: disc


### PR DESCRIPTION
## Summary
- Remove `meetup_location` and `meetup_time` from the `recovery_events` select query
- These columns don't exist in `recovery_events` table (they're in `meetup_proposals`)
- This was causing "column does not exist" database errors

## Test plan
- [ ] Profile page loads without errors
- [ ] Found Disc tab shows pending returns correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)