### PR TITLE
fix: include abandoned status in get-my-finds

### DIFF
--- a/supabase/functions/get-my-finds/index.ts
+++ b/supabase/functions/get-my-finds/index.ts
@@ -79,7 +79,7 @@ Deno.serve(async (req) => {
     `
     )
     .eq('finder_id', user.id)
-    .in('status', ['found', 'meetup_proposed', 'meetup_confirmed', 'dropped_off'])
+    .in('status', ['found', 'meetup_proposed', 'meetup_confirmed', 'dropped_off', 'abandoned'])
     .order('created_at', { ascending: false });
 
   if (recoveriesError) {
@@ -107,8 +107,11 @@ Deno.serve(async (req) => {
       } | null;
 
       // Get owner display name
+      // For abandoned discs, owner_id is null
       let ownerDisplayName = 'Anonymous';
-      if (disc?.owner_id) {
+      if (recovery.status === 'abandoned' || !disc?.owner_id) {
+        ownerDisplayName = 'No owner';
+      } else if (disc?.owner_id) {
         const { data: profile } = await supabaseAdmin
           .from('profiles')
           .select('username, full_name, display_preference, email')


### PR DESCRIPTION
## Summary
- Add `abandoned` to status filter so finders see abandoned discs in their list
- Show "No owner" for abandoned discs instead of owner name

🤖 Generated with [Claude Code](https://claude.com/claude-code)