### PR TITLE
feat: add QR code assignment and disc linking functions

### DIFF
--- a/supabase/functions/assign-qr-code/index.test.ts
+++ b/supabase/functions/assign-qr-code/index.test.ts
@@ -1,0 +1,360 @@
+import { assertEquals, assertExists } from 'https://deno.land/std@0.192.0/testing/asserts.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const FUNCTION_URL = Deno.env.get('FUNCTION_URL') || 'http://localhost:54321/functions/v1/assign-qr-code';
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL') || 'http://localhost:54321';
+const SUPABASE_ANON_KEY =
+  Deno.env.get('SUPABASE_ANON_KEY') ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0';
+const SUPABASE_SERVICE_ROLE_KEY =
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU';
+
+Deno.test('assign-qr-code: should return 405 for non-POST requests', async () => {
+  const response = await fetch(FUNCTION_URL, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  assertEquals(response.status, 405);
+  const data = await response.json();
+  assertEquals(data.error, 'Method not allowed');
+});
+
+Deno.test('assign-qr-code: should return 401 when not authenticated', async () => {
+  const response = await fetch(FUNCTION_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ qr_code: 'ABC123' }),
+  });
+
+  assertEquals(response.status, 401);
+  const data = await response.json();
+  assertEquals(data.error, 'Missing authorization header');
+});
+
+Deno.test('assign-qr-code: should return 400 when qr_code is missing', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session) {
+    throw signUpError || new Error('No session');
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({}),
+    });
+
+    assertEquals(response.status, 400);
+    const data = await response.json();
+    assertEquals(data.error, 'Missing qr_code in request body');
+  } finally {
+    const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user!.id);
+  }
+});
+
+Deno.test("assign-qr-code: should return 400 when QR code doesn't exist", async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session) {
+    throw signUpError || new Error('No session');
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({ qr_code: 'NONEXISTENT123' }),
+    });
+
+    assertEquals(response.status, 400);
+    const data = await response.json();
+    assertEquals(data.error, 'QR code not found');
+  } finally {
+    const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user!.id);
+  }
+});
+
+Deno.test('assign-qr-code: should return 400 when QR code is already assigned', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  // Sign up a test user
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  // Sign up another user who "owns" the QR code
+  const { data: otherAuth, error: otherError } = await supabase.auth.signUp({
+    email: `other-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (otherError || !otherAuth.user) {
+    throw otherError || new Error('No user');
+  }
+
+  // Create an already-assigned QR code
+  const testCode = `ASSIGNED${Date.now()}`;
+  const { data: qrCode, error: createError } = await supabaseAdmin
+    .from('qr_codes')
+    .insert({ short_code: testCode, status: 'assigned', assigned_to: otherAuth.user.id })
+    .select()
+    .single();
+
+  if (createError) {
+    throw createError;
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({ qr_code: testCode }),
+    });
+
+    assertEquals(response.status, 400);
+    const data = await response.json();
+    assertEquals(data.error, 'QR code is already assigned');
+  } finally {
+    await supabaseAdmin.from('qr_codes').delete().eq('id', qrCode.id);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+    await supabaseAdmin.auth.admin.deleteUser(otherAuth.user.id);
+  }
+});
+
+Deno.test('assign-qr-code: should return 400 when QR code is already active', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  // Sign up another user who "owns" the QR code
+  const { data: otherAuth, error: otherError } = await supabase.auth.signUp({
+    email: `other-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (otherError || !otherAuth.user) {
+    throw otherError || new Error('No user');
+  }
+
+  // Create an active QR code
+  const testCode = `ACTIVE${Date.now()}`;
+  const { data: qrCode, error: createError } = await supabaseAdmin
+    .from('qr_codes')
+    .insert({ short_code: testCode, status: 'active', assigned_to: otherAuth.user.id })
+    .select()
+    .single();
+
+  if (createError) {
+    throw createError;
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({ qr_code: testCode }),
+    });
+
+    assertEquals(response.status, 400);
+    const data = await response.json();
+    assertEquals(data.error, 'QR code is already in use');
+  } finally {
+    await supabaseAdmin.from('qr_codes').delete().eq('id', qrCode.id);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+    await supabaseAdmin.auth.admin.deleteUser(otherAuth.user.id);
+  }
+});
+
+Deno.test('assign-qr-code: should return 400 when QR code is deactivated', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  // Create a deactivated QR code
+  const testCode = `DEACTIVATED${Date.now()}`;
+  const { data: qrCode, error: createError } = await supabaseAdmin
+    .from('qr_codes')
+    .insert({ short_code: testCode, status: 'deactivated' })
+    .select()
+    .single();
+
+  if (createError) {
+    throw createError;
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({ qr_code: testCode }),
+    });
+
+    assertEquals(response.status, 400);
+    const data = await response.json();
+    assertEquals(data.error, 'QR code has been deactivated');
+  } finally {
+    await supabaseAdmin.from('qr_codes').delete().eq('id', qrCode.id);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});
+
+Deno.test('assign-qr-code: should successfully assign QR code to user', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  // Create an unassigned (generated) QR code
+  const testCode = `GENERATED${Date.now()}`;
+  const { data: qrCode, error: createError } = await supabaseAdmin
+    .from('qr_codes')
+    .insert({ short_code: testCode, status: 'generated' })
+    .select()
+    .single();
+
+  if (createError) {
+    throw createError;
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({ qr_code: testCode }),
+    });
+
+    assertEquals(response.status, 200);
+    const data = await response.json();
+    assertEquals(data.success, true);
+    assertExists(data.qr_code);
+    assertEquals(data.qr_code.id, qrCode.id);
+    assertEquals(data.qr_code.short_code, testCode);
+    assertEquals(data.qr_code.status, 'assigned');
+    assertEquals(data.qr_code.assigned_to, authData.user.id);
+
+    // Verify in database
+    const { data: updatedQr } = await supabaseAdmin
+      .from('qr_codes')
+      .select('*')
+      .eq('id', qrCode.id)
+      .single();
+
+    assertEquals(updatedQr?.status, 'assigned');
+    assertEquals(updatedQr?.assigned_to, authData.user.id);
+  } finally {
+    await supabaseAdmin.from('qr_codes').delete().eq('id', qrCode.id);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});
+
+Deno.test('assign-qr-code: should be case insensitive for QR code lookup', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  // Create a QR code with uppercase
+  const testCode = `CASETEST${Date.now()}`;
+  const { data: qrCode, error: createError } = await supabaseAdmin
+    .from('qr_codes')
+    .insert({ short_code: testCode, status: 'generated' })
+    .select()
+    .single();
+
+  if (createError) {
+    throw createError;
+  }
+
+  try {
+    // Send lowercase QR code
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({ qr_code: testCode.toLowerCase() }),
+    });
+
+    assertEquals(response.status, 200);
+    const data = await response.json();
+    assertEquals(data.success, true);
+    assertEquals(data.qr_code.status, 'assigned');
+  } finally {
+    await supabaseAdmin.from('qr_codes').delete().eq('id', qrCode.id);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});

--- a/supabase/functions/assign-qr-code/index.ts
+++ b/supabase/functions/assign-qr-code/index.ts
@@ -1,0 +1,158 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+/**
+ * Assign QR Code Function
+ *
+ * Allows a user to claim an unassigned QR code.
+ *
+ * POST /assign-qr-code
+ * Body: { qr_code: string }
+ *
+ * Returns:
+ * - QR code details with updated status
+ */
+
+Deno.serve(async (req) => {
+  // Only allow POST requests
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Check authentication
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) {
+    return new Response(JSON.stringify({ error: 'Missing authorization header' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Create Supabase client
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+  const supabaseKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
+  const supabase = createClient(supabaseUrl, supabaseKey, {
+    global: {
+      headers: { Authorization: authHeader },
+    },
+  });
+
+  // Verify user is authenticated
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Parse request body
+  let body: { qr_code?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Validate qr_code is provided
+  if (!body.qr_code) {
+    return new Response(JSON.stringify({ error: 'Missing qr_code in request body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Create service role client for database operations
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+  const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
+
+  // Look up QR code (case insensitive)
+  const { data: qrCode, error: qrError } = await supabaseAdmin
+    .from('qr_codes')
+    .select('*')
+    .ilike('short_code', body.qr_code)
+    .single();
+
+  if (qrError || !qrCode) {
+    return new Response(JSON.stringify({ error: 'QR code not found' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Check QR code status
+  if (qrCode.status === 'assigned') {
+    return new Response(JSON.stringify({ error: 'QR code is already assigned' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (qrCode.status === 'active') {
+    return new Response(JSON.stringify({ error: 'QR code is already in use' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (qrCode.status === 'deactivated') {
+    return new Response(JSON.stringify({ error: 'QR code has been deactivated' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // QR code must be in 'generated' status to be assigned
+  if (qrCode.status !== 'generated') {
+    return new Response(JSON.stringify({ error: 'QR code cannot be assigned' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Update QR code to assigned status
+  const { data: updatedQr, error: updateError } = await supabaseAdmin
+    .from('qr_codes')
+    .update({
+      status: 'assigned',
+      assigned_to: user.id,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', qrCode.id)
+    .select()
+    .single();
+
+  if (updateError || !updatedQr) {
+    console.error('Failed to update QR code:', updateError);
+    return new Response(JSON.stringify({ error: 'Failed to assign QR code' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  return new Response(
+    JSON.stringify({
+      success: true,
+      qr_code: {
+        id: updatedQr.id,
+        short_code: updatedQr.short_code,
+        status: updatedQr.status,
+        assigned_to: updatedQr.assigned_to,
+      },
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
+});

--- a/supabase/functions/link-qr-to-disc/index.test.ts
+++ b/supabase/functions/link-qr-to-disc/index.test.ts
@@ -1,0 +1,606 @@
+import { assertEquals, assertExists } from 'https://deno.land/std@0.192.0/testing/asserts.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const FUNCTION_URL = Deno.env.get('FUNCTION_URL') || 'http://localhost:54321/functions/v1/link-qr-to-disc';
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL') || 'http://localhost:54321';
+const SUPABASE_ANON_KEY =
+  Deno.env.get('SUPABASE_ANON_KEY') ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0';
+const SUPABASE_SERVICE_ROLE_KEY =
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU';
+
+Deno.test('link-qr-to-disc: should return 405 for non-POST requests', async () => {
+  const response = await fetch(FUNCTION_URL, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  assertEquals(response.status, 405);
+  const data = await response.json();
+  assertEquals(data.error, 'Method not allowed');
+});
+
+Deno.test('link-qr-to-disc: should return 401 when not authenticated', async () => {
+  const response = await fetch(FUNCTION_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ qr_code: 'ABC123', disc_id: '123' }),
+  });
+
+  assertEquals(response.status, 401);
+  const data = await response.json();
+  assertEquals(data.error, 'Missing authorization header');
+});
+
+Deno.test('link-qr-to-disc: should return 400 when qr_code is missing', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session) {
+    throw signUpError || new Error('No session');
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({ disc_id: '123' }),
+    });
+
+    assertEquals(response.status, 400);
+    const data = await response.json();
+    assertEquals(data.error, 'Missing qr_code in request body');
+  } finally {
+    const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user!.id);
+  }
+});
+
+Deno.test('link-qr-to-disc: should return 400 when disc_id is missing', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session) {
+    throw signUpError || new Error('No session');
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({ qr_code: 'ABC123' }),
+    });
+
+    assertEquals(response.status, 400);
+    const data = await response.json();
+    assertEquals(data.error, 'Missing disc_id in request body');
+  } finally {
+    const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user!.id);
+  }
+});
+
+Deno.test("link-qr-to-disc: should return 400 when QR code doesn't exist", async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  // Create a disc for this user
+  const { data: disc, error: discError } = await supabaseAdmin
+    .from('discs')
+    .insert({
+      owner_id: authData.user.id,
+      name: 'Test Disc',
+      mold: 'Destroyer',
+    })
+    .select()
+    .single();
+
+  if (discError) {
+    throw discError;
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({ qr_code: 'NONEXISTENT123', disc_id: disc.id }),
+    });
+
+    assertEquals(response.status, 400);
+    const data = await response.json();
+    assertEquals(data.error, 'QR code not found');
+  } finally {
+    await supabaseAdmin.from('discs').delete().eq('id', disc.id);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});
+
+Deno.test('link-qr-to-disc: should return 403 when QR code not assigned to current user', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  // Sign up test user
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  // Sign up another user who owns the QR code
+  const { data: otherAuth, error: otherError } = await supabase.auth.signUp({
+    email: `other-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (otherError || !otherAuth.user) {
+    throw otherError || new Error('No user');
+  }
+
+  // Create QR code assigned to other user
+  const testCode = `OTHERUSER${Date.now()}`;
+  const { data: qrCode, error: qrError } = await supabaseAdmin
+    .from('qr_codes')
+    .insert({ short_code: testCode, status: 'assigned', assigned_to: otherAuth.user.id })
+    .select()
+    .single();
+
+  if (qrError) {
+    throw qrError;
+  }
+
+  // Create disc owned by test user
+  const { data: disc, error: discError } = await supabaseAdmin
+    .from('discs')
+    .insert({
+      owner_id: authData.user.id,
+      name: 'My Disc',
+      mold: 'Destroyer',
+    })
+    .select()
+    .single();
+
+  if (discError) {
+    throw discError;
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({ qr_code: testCode, disc_id: disc.id }),
+    });
+
+    assertEquals(response.status, 403);
+    const data = await response.json();
+    assertEquals(data.error, 'QR code is not assigned to you');
+  } finally {
+    await supabaseAdmin.from('discs').delete().eq('id', disc.id);
+    await supabaseAdmin.from('qr_codes').delete().eq('id', qrCode.id);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+    await supabaseAdmin.auth.admin.deleteUser(otherAuth.user.id);
+  }
+});
+
+Deno.test("link-qr-to-disc: should return 400 when QR code is not in 'assigned' status", async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  // Create QR code in 'generated' status (not assigned)
+  const testCode = `GENERATED${Date.now()}`;
+  const { data: qrCode, error: qrError } = await supabaseAdmin
+    .from('qr_codes')
+    .insert({ short_code: testCode, status: 'generated' })
+    .select()
+    .single();
+
+  if (qrError) {
+    throw qrError;
+  }
+
+  // Create disc
+  const { data: disc, error: discError } = await supabaseAdmin
+    .from('discs')
+    .insert({
+      owner_id: authData.user.id,
+      name: 'My Disc',
+      mold: 'Destroyer',
+    })
+    .select()
+    .single();
+
+  if (discError) {
+    throw discError;
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({ qr_code: testCode, disc_id: disc.id }),
+    });
+
+    assertEquals(response.status, 400);
+    const data = await response.json();
+    assertEquals(data.error, 'QR code must be assigned before linking to a disc');
+  } finally {
+    await supabaseAdmin.from('discs').delete().eq('id', disc.id);
+    await supabaseAdmin.from('qr_codes').delete().eq('id', qrCode.id);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});
+
+Deno.test("link-qr-to-disc: should return 400 when disc doesn't exist", async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  // Create QR code assigned to user
+  const testCode = `NODISC${Date.now()}`;
+  const { data: qrCode, error: qrError } = await supabaseAdmin
+    .from('qr_codes')
+    .insert({ short_code: testCode, status: 'assigned', assigned_to: authData.user.id })
+    .select()
+    .single();
+
+  if (qrError) {
+    throw qrError;
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({ qr_code: testCode, disc_id: '00000000-0000-0000-0000-000000000000' }),
+    });
+
+    assertEquals(response.status, 400);
+    const data = await response.json();
+    assertEquals(data.error, 'Disc not found');
+  } finally {
+    await supabaseAdmin.from('qr_codes').delete().eq('id', qrCode.id);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});
+
+Deno.test('link-qr-to-disc: should return 403 when disc not owned by current user', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  // Sign up test user
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  // Sign up other user who owns the disc
+  const { data: otherAuth, error: otherError } = await supabase.auth.signUp({
+    email: `other-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (otherError || !otherAuth.user) {
+    throw otherError || new Error('No user');
+  }
+
+  // Create QR code assigned to test user
+  const testCode = `NOTMYDISC${Date.now()}`;
+  const { data: qrCode, error: qrError } = await supabaseAdmin
+    .from('qr_codes')
+    .insert({ short_code: testCode, status: 'assigned', assigned_to: authData.user.id })
+    .select()
+    .single();
+
+  if (qrError) {
+    throw qrError;
+  }
+
+  // Create disc owned by other user
+  const { data: disc, error: discError } = await supabaseAdmin
+    .from('discs')
+    .insert({
+      owner_id: otherAuth.user.id,
+      name: 'Not My Disc',
+      mold: 'Destroyer',
+    })
+    .select()
+    .single();
+
+  if (discError) {
+    throw discError;
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({ qr_code: testCode, disc_id: disc.id }),
+    });
+
+    assertEquals(response.status, 403);
+    const data = await response.json();
+    assertEquals(data.error, 'You do not own this disc');
+  } finally {
+    await supabaseAdmin.from('discs').delete().eq('id', disc.id);
+    await supabaseAdmin.from('qr_codes').delete().eq('id', qrCode.id);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+    await supabaseAdmin.auth.admin.deleteUser(otherAuth.user.id);
+  }
+});
+
+Deno.test('link-qr-to-disc: should return 400 when disc already has a QR code', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  // Create existing QR code linked to disc
+  const existingCode = `EXISTING${Date.now()}`;
+  const { data: existingQr, error: existingQrError } = await supabaseAdmin
+    .from('qr_codes')
+    .insert({ short_code: existingCode, status: 'active', assigned_to: authData.user.id })
+    .select()
+    .single();
+
+  if (existingQrError) {
+    throw existingQrError;
+  }
+
+  // Create disc with existing QR code
+  const { data: disc, error: discError } = await supabaseAdmin
+    .from('discs')
+    .insert({
+      owner_id: authData.user.id,
+      qr_code_id: existingQr.id,
+      name: 'Already Linked Disc',
+      mold: 'Destroyer',
+    })
+    .select()
+    .single();
+
+  if (discError) {
+    throw discError;
+  }
+
+  // Create new QR code to try to link
+  const newCode = `NEWQR${Date.now()}`;
+  const { data: newQr, error: newQrError } = await supabaseAdmin
+    .from('qr_codes')
+    .insert({ short_code: newCode, status: 'assigned', assigned_to: authData.user.id })
+    .select()
+    .single();
+
+  if (newQrError) {
+    throw newQrError;
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({ qr_code: newCode, disc_id: disc.id }),
+    });
+
+    assertEquals(response.status, 400);
+    const data = await response.json();
+    assertEquals(data.error, 'Disc already has a QR code linked');
+  } finally {
+    await supabaseAdmin.from('discs').delete().eq('id', disc.id);
+    await supabaseAdmin.from('qr_codes').delete().eq('id', existingQr.id);
+    await supabaseAdmin.from('qr_codes').delete().eq('id', newQr.id);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});
+
+Deno.test('link-qr-to-disc: should successfully link QR code to disc', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  // Create QR code assigned to user
+  const testCode = `LINKME${Date.now()}`;
+  const { data: qrCode, error: qrError } = await supabaseAdmin
+    .from('qr_codes')
+    .insert({ short_code: testCode, status: 'assigned', assigned_to: authData.user.id })
+    .select()
+    .single();
+
+  if (qrError) {
+    throw qrError;
+  }
+
+  // Create disc without QR code
+  const { data: disc, error: discError } = await supabaseAdmin
+    .from('discs')
+    .insert({
+      owner_id: authData.user.id,
+      name: 'Link Me Disc',
+      mold: 'Destroyer',
+    })
+    .select()
+    .single();
+
+  if (discError) {
+    throw discError;
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({ qr_code: testCode, disc_id: disc.id }),
+    });
+
+    assertEquals(response.status, 200);
+    const data = await response.json();
+    assertEquals(data.success, true);
+    assertExists(data.disc);
+    assertEquals(data.disc.id, disc.id);
+    assertEquals(data.disc.qr_code_id, qrCode.id);
+    assertExists(data.qr_code);
+    assertEquals(data.qr_code.id, qrCode.id);
+    assertEquals(data.qr_code.status, 'active');
+
+    // Verify disc updated in database
+    const { data: updatedDisc } = await supabaseAdmin.from('discs').select('*').eq('id', disc.id).single();
+
+    assertEquals(updatedDisc?.qr_code_id, qrCode.id);
+
+    // Verify QR code status updated in database
+    const { data: updatedQr } = await supabaseAdmin.from('qr_codes').select('*').eq('id', qrCode.id).single();
+
+    assertEquals(updatedQr?.status, 'active');
+  } finally {
+    await supabaseAdmin.from('discs').delete().eq('id', disc.id);
+    await supabaseAdmin.from('qr_codes').delete().eq('id', qrCode.id);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});
+
+Deno.test('link-qr-to-disc: should be case insensitive for QR code lookup', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  // Create QR code with uppercase
+  const testCode = `CASELINK${Date.now()}`;
+  const { data: qrCode, error: qrError } = await supabaseAdmin
+    .from('qr_codes')
+    .insert({ short_code: testCode, status: 'assigned', assigned_to: authData.user.id })
+    .select()
+    .single();
+
+  if (qrError) {
+    throw qrError;
+  }
+
+  // Create disc
+  const { data: disc, error: discError } = await supabaseAdmin
+    .from('discs')
+    .insert({
+      owner_id: authData.user.id,
+      name: 'Case Test Disc',
+      mold: 'Destroyer',
+    })
+    .select()
+    .single();
+
+  if (discError) {
+    throw discError;
+  }
+
+  try {
+    // Send lowercase QR code
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({ qr_code: testCode.toLowerCase(), disc_id: disc.id }),
+    });
+
+    assertEquals(response.status, 200);
+    const data = await response.json();
+    assertEquals(data.success, true);
+  } finally {
+    await supabaseAdmin.from('discs').delete().eq('id', disc.id);
+    await supabaseAdmin.from('qr_codes').delete().eq('id', qrCode.id);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});

--- a/supabase/functions/link-qr-to-disc/index.ts
+++ b/supabase/functions/link-qr-to-disc/index.ts
@@ -1,0 +1,205 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+/**
+ * Link QR Code to Disc Function
+ *
+ * Links an assigned QR code to an existing disc owned by the user.
+ *
+ * POST /link-qr-to-disc
+ * Body: { qr_code: string, disc_id: string }
+ *
+ * Returns:
+ * - Disc and QR code details with updated status
+ */
+
+Deno.serve(async (req) => {
+  // Only allow POST requests
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Check authentication
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) {
+    return new Response(JSON.stringify({ error: 'Missing authorization header' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Create Supabase client
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+  const supabaseKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
+  const supabase = createClient(supabaseUrl, supabaseKey, {
+    global: {
+      headers: { Authorization: authHeader },
+    },
+  });
+
+  // Verify user is authenticated
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Parse request body
+  let body: { qr_code?: string; disc_id?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Validate required fields
+  if (!body.qr_code) {
+    return new Response(JSON.stringify({ error: 'Missing qr_code in request body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (!body.disc_id) {
+    return new Response(JSON.stringify({ error: 'Missing disc_id in request body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Create service role client for database operations
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+  const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
+
+  // Look up QR code (case insensitive)
+  const { data: qrCode, error: qrError } = await supabaseAdmin
+    .from('qr_codes')
+    .select('*')
+    .ilike('short_code', body.qr_code)
+    .single();
+
+  if (qrError || !qrCode) {
+    return new Response(JSON.stringify({ error: 'QR code not found' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Check QR code is assigned to current user
+  if (qrCode.assigned_to !== user.id) {
+    return new Response(JSON.stringify({ error: 'QR code is not assigned to you' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Check QR code is in 'assigned' status
+  if (qrCode.status !== 'assigned') {
+    return new Response(JSON.stringify({ error: 'QR code must be assigned before linking to a disc' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Look up disc
+  const { data: disc, error: discError } = await supabaseAdmin
+    .from('discs')
+    .select('*')
+    .eq('id', body.disc_id)
+    .single();
+
+  if (discError || !disc) {
+    return new Response(JSON.stringify({ error: 'Disc not found' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Check disc is owned by current user
+  if (disc.owner_id !== user.id) {
+    return new Response(JSON.stringify({ error: 'You do not own this disc' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Check disc doesn't already have a QR code
+  if (disc.qr_code_id) {
+    return new Response(JSON.stringify({ error: 'Disc already has a QR code linked' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Update disc with QR code reference
+  const { data: updatedDisc, error: updateDiscError } = await supabaseAdmin
+    .from('discs')
+    .update({
+      qr_code_id: qrCode.id,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', disc.id)
+    .select()
+    .single();
+
+  if (updateDiscError || !updatedDisc) {
+    console.error('Failed to update disc:', updateDiscError);
+    return new Response(JSON.stringify({ error: 'Failed to link QR code to disc' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Update QR code status to 'active'
+  const { data: updatedQr, error: updateQrError } = await supabaseAdmin
+    .from('qr_codes')
+    .update({
+      status: 'active',
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', qrCode.id)
+    .select()
+    .single();
+
+  if (updateQrError || !updatedQr) {
+    console.error('Failed to update QR code:', updateQrError);
+    // Rollback disc update
+    await supabaseAdmin.from('discs').update({ qr_code_id: null }).eq('id', disc.id);
+    return new Response(JSON.stringify({ error: 'Failed to activate QR code' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  return new Response(
+    JSON.stringify({
+      success: true,
+      disc: {
+        id: updatedDisc.id,
+        name: updatedDisc.name,
+        qr_code_id: updatedDisc.qr_code_id,
+      },
+      qr_code: {
+        id: updatedQr.id,
+        short_code: updatedQr.short_code,
+        status: updatedQr.status,
+      },
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- **assign-qr-code**: Allows users to claim unassigned QR codes
  - Validates QR code exists and is in 'generated' status
  - Updates status to 'assigned' and sets `assigned_to` to current user
  - Case insensitive QR code lookup

- **link-qr-to-disc**: Links an assigned QR code to an existing disc
  - Validates user owns both the QR code and disc
  - Validates disc doesn't already have a QR code
  - Updates disc's `qr_code_id` and QR code status to 'active'
  - Case insensitive QR code lookup

## User Flow
1. User scans a new QR code sticker
2. Calls `assign-qr-code` to claim it (status: generated → assigned)
3. User can then:
   - Call `link-qr-to-disc` to attach it to an existing disc (status: assigned → active)
   - Or create a new disc with the QR code via `create-disc`

## Test Plan
- [ ] assign-qr-code: 405 for non-POST
- [ ] assign-qr-code: 401 when not authenticated
- [ ] assign-qr-code: 400 when QR code missing
- [ ] assign-qr-code: 400 when QR code doesn't exist
- [ ] assign-qr-code: 400 when QR code already assigned/active/deactivated
- [ ] assign-qr-code: Successfully assigns QR code to user
- [ ] link-qr-to-disc: 405 for non-POST
- [ ] link-qr-to-disc: 401 when not authenticated
- [ ] link-qr-to-disc: 400/403 for various validation failures
- [ ] link-qr-to-disc: Successfully links QR code to disc

Closes #110, Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)