### PR TITLE
feat: enhance lookup-qr-code to return QR status for unclaimed codes

### DIFF
--- a/supabase/functions/assign-qr-code/index.test.ts
+++ b/supabase/functions/assign-qr-code/index.test.ts
@@ -299,11 +299,7 @@ Deno.test('assign-qr-code: should successfully assign QR code to user', async ()
     assertEquals(data.qr_code.assigned_to, authData.user.id);
 
     // Verify in database
-    const { data: updatedQr } = await supabaseAdmin
-      .from('qr_codes')
-      .select('*')
-      .eq('id', qrCode.id)
-      .single();
+    const { data: updatedQr } = await supabaseAdmin.from('qr_codes').select('*').eq('id', qrCode.id).single();
 
     assertEquals(updatedQr?.status, 'assigned');
     assertEquals(updatedQr?.assigned_to, authData.user.id);


### PR DESCRIPTION
## Summary
Enhances the `lookup-qr-code` endpoint to return information about QR codes that exist but aren't linked to discs yet.

### New Response Fields
- `qr_exists`: boolean - whether the QR code exists in the system
- `qr_status`: string - status of the QR code ('generated', 'assigned', 'deactivated')
- `qr_code`: string - the QR code short code
- `is_assignee`: boolean - whether authenticated user owns this assigned QR code

### Response Examples

**QR code doesn't exist:**
```json
{ "found": false, "qr_exists": false }
```

**Unclaimed QR code (can be claimed):**
```json
{ "found": false, "qr_exists": true, "qr_status": "generated", "qr_code": "ABC123" }
```

**Assigned but not linked to disc:**
```json
{ "found": false, "qr_exists": true, "qr_status": "assigned", "qr_code": "ABC123", "is_assignee": true }
```

**Deactivated QR code:**
```json
{ "found": false, "qr_exists": true, "qr_status": "deactivated" }
```

## Test Plan
- [x] Return qr_exists=false for non-existent QR codes
- [x] Return qr_status=generated for unclaimed QR codes
- [x] Return qr_status=assigned for assigned but unlinked QR codes
- [x] Return qr_status=deactivated for deactivated QR codes
- [x] Return is_assignee=true when authenticated user owns assigned QR
- [x] Existing disc lookup tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)