### PR TITLE
feat: add unlink-qr-code function

### DIFF
--- a/supabase/functions/unlink-qr-code/index.test.ts
+++ b/supabase/functions/unlink-qr-code/index.test.ts
@@ -1,0 +1,305 @@
+import { assertEquals, assertExists } from 'https://deno.land/std@0.192.0/testing/asserts.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const FUNCTION_URL =
+  Deno.env.get('FUNCTION_URL') || 'http://localhost:54321/functions/v1/unlink-qr-code';
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL') || 'http://localhost:54321';
+const SUPABASE_ANON_KEY =
+  Deno.env.get('SUPABASE_ANON_KEY') ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0';
+const SUPABASE_SERVICE_ROLE_KEY =
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU';
+
+Deno.test('unlink-qr-code: should return 405 for non-POST requests', async () => {
+  const response = await fetch(FUNCTION_URL, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  assertEquals(response.status, 405);
+  const data = await response.json();
+  assertEquals(data.error, 'Method not allowed');
+});
+
+Deno.test('unlink-qr-code: should return 401 when not authenticated', async () => {
+  const response = await fetch(FUNCTION_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ disc_id: '123' }),
+  });
+
+  assertEquals(response.status, 401);
+  const data = await response.json();
+  assertEquals(data.error, 'Missing authorization header');
+});
+
+Deno.test('unlink-qr-code: should return 400 when disc_id is missing', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session) {
+    throw signUpError || new Error('No session');
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({}),
+    });
+
+    assertEquals(response.status, 400);
+    const data = await response.json();
+    assertEquals(data.error, 'Missing disc_id in request body');
+  } finally {
+    const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user!.id);
+  }
+});
+
+Deno.test("unlink-qr-code: should return 400 when disc doesn't exist", async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({ disc_id: '00000000-0000-0000-0000-000000000000' }),
+    });
+
+    assertEquals(response.status, 400);
+    const data = await response.json();
+    assertEquals(data.error, 'Disc not found');
+  } finally {
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});
+
+Deno.test('unlink-qr-code: should return 403 when disc not owned by current user', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  // Sign up test user
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  // Sign up other user who owns the disc
+  const { data: otherAuth, error: otherError } = await supabase.auth.signUp({
+    email: `other-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (otherError || !otherAuth.user) {
+    throw otherError || new Error('No user');
+  }
+
+  // Create QR code
+  const testCode = `UNLINK${Date.now()}`;
+  const { data: qrCode, error: qrError } = await supabaseAdmin
+    .from('qr_codes')
+    .insert({ short_code: testCode, status: 'active', assigned_to: otherAuth.user.id })
+    .select()
+    .single();
+
+  if (qrError) {
+    throw qrError;
+  }
+
+  // Create disc owned by other user
+  const { data: disc, error: discError } = await supabaseAdmin
+    .from('discs')
+    .insert({
+      owner_id: otherAuth.user.id,
+      qr_code_id: qrCode.id,
+      name: 'Not My Disc',
+      mold: 'Destroyer',
+    })
+    .select()
+    .single();
+
+  if (discError) {
+    throw discError;
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({ disc_id: disc.id }),
+    });
+
+    assertEquals(response.status, 403);
+    const data = await response.json();
+    assertEquals(data.error, 'You do not own this disc');
+  } finally {
+    await supabaseAdmin.from('discs').delete().eq('id', disc.id);
+    await supabaseAdmin.from('qr_codes').delete().eq('id', qrCode.id);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+    await supabaseAdmin.auth.admin.deleteUser(otherAuth.user.id);
+  }
+});
+
+Deno.test('unlink-qr-code: should return 400 when disc has no QR code linked', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  // Create disc without QR code
+  const { data: disc, error: discError } = await supabaseAdmin
+    .from('discs')
+    .insert({
+      owner_id: authData.user.id,
+      name: 'No QR Disc',
+      mold: 'Destroyer',
+    })
+    .select()
+    .single();
+
+  if (discError) {
+    throw discError;
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({ disc_id: disc.id }),
+    });
+
+    assertEquals(response.status, 400);
+    const data = await response.json();
+    assertEquals(data.error, 'Disc has no QR code linked');
+  } finally {
+    await supabaseAdmin.from('discs').delete().eq('id', disc.id);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});
+
+Deno.test('unlink-qr-code: should successfully unlink and delete QR code from disc', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  // Create QR code
+  const testCode = `DELETEME${Date.now()}`;
+  const { data: qrCode, error: qrError } = await supabaseAdmin
+    .from('qr_codes')
+    .insert({ short_code: testCode, status: 'active', assigned_to: authData.user.id })
+    .select()
+    .single();
+
+  if (qrError) {
+    throw qrError;
+  }
+
+  // Create disc with QR code
+  const { data: disc, error: discError } = await supabaseAdmin
+    .from('discs')
+    .insert({
+      owner_id: authData.user.id,
+      qr_code_id: qrCode.id,
+      name: 'Unlink Me Disc',
+      mold: 'Destroyer',
+    })
+    .select()
+    .single();
+
+  if (discError) {
+    throw discError;
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({ disc_id: disc.id }),
+    });
+
+    assertEquals(response.status, 200);
+    const data = await response.json();
+    assertEquals(data.success, true);
+    assertExists(data.disc);
+    assertEquals(data.disc.id, disc.id);
+    assertEquals(data.disc.qr_code_id, null);
+
+    // Verify disc updated in database
+    const { data: updatedDisc } = await supabaseAdmin
+      .from('discs')
+      .select('*')
+      .eq('id', disc.id)
+      .single();
+
+    assertEquals(updatedDisc?.qr_code_id, null);
+
+    // Verify QR code deleted from database
+    const { data: deletedQr } = await supabaseAdmin
+      .from('qr_codes')
+      .select('*')
+      .eq('id', qrCode.id)
+      .maybeSingle();
+
+    assertEquals(deletedQr, null);
+  } finally {
+    // Cleanup disc (QR code should already be deleted)
+    await supabaseAdmin.from('discs').delete().eq('id', disc.id);
+    // Just in case test failed before QR deletion
+    await supabaseAdmin.from('qr_codes').delete().eq('id', qrCode.id);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});

--- a/supabase/functions/unlink-qr-code/index.ts
+++ b/supabase/functions/unlink-qr-code/index.ts
@@ -1,0 +1,158 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+/**
+ * Unlink QR Code from Disc Function
+ *
+ * Removes a QR code from a disc and deletes it from the database.
+ * Only the disc owner can unlink the QR code.
+ *
+ * POST /unlink-qr-code
+ * Body: { disc_id: string }
+ *
+ * Returns:
+ * - Disc details with qr_code_id set to null
+ */
+
+Deno.serve(async (req) => {
+  // Only allow POST requests
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Check authentication
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) {
+    return new Response(JSON.stringify({ error: 'Missing authorization header' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Create Supabase client
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+  const supabaseKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
+  const supabase = createClient(supabaseUrl, supabaseKey, {
+    global: {
+      headers: { Authorization: authHeader },
+    },
+  });
+
+  // Verify user is authenticated
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Parse request body
+  let body: { disc_id?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Validate required fields
+  if (!body.disc_id) {
+    return new Response(JSON.stringify({ error: 'Missing disc_id in request body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Create service role client for database operations
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+  const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey);
+
+  // Look up disc
+  const { data: disc, error: discError } = await supabaseAdmin
+    .from('discs')
+    .select('*')
+    .eq('id', body.disc_id)
+    .single();
+
+  if (discError || !disc) {
+    return new Response(JSON.stringify({ error: 'Disc not found' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Check disc is owned by current user
+  if (disc.owner_id !== user.id) {
+    return new Response(JSON.stringify({ error: 'You do not own this disc' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Check disc has a QR code linked
+  if (!disc.qr_code_id) {
+    return new Response(JSON.stringify({ error: 'Disc has no QR code linked' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const qrCodeId = disc.qr_code_id;
+
+  // Update disc to remove QR code reference
+  const { data: updatedDisc, error: updateDiscError } = await supabaseAdmin
+    .from('discs')
+    .update({
+      qr_code_id: null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', disc.id)
+    .select()
+    .single();
+
+  if (updateDiscError || !updatedDisc) {
+    console.error('Failed to update disc:', updateDiscError);
+    return new Response(JSON.stringify({ error: 'Failed to unlink QR code from disc' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Delete the QR code from the database
+  const { error: deleteQrError } = await supabaseAdmin.from('qr_codes').delete().eq('id', qrCodeId);
+
+  if (deleteQrError) {
+    console.error('Failed to delete QR code:', deleteQrError);
+    // Rollback disc update
+    await supabaseAdmin.from('discs').update({ qr_code_id: qrCodeId }).eq('id', disc.id);
+    return new Response(JSON.stringify({ error: 'Failed to delete QR code' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  return new Response(
+    JSON.stringify({
+      success: true,
+      disc: {
+        id: updatedDisc.id,
+        name: updatedDisc.name,
+        qr_code_id: updatedDisc.qr_code_id,
+      },
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- Adds new `unlink-qr-code` edge function to remove QR codes from discs
- When called, removes the QR code reference from the disc and deletes the QR code from the database entirely
- Only the disc owner can unlink a QR code

## Changes
- `POST /unlink-qr-code` - accepts `{ disc_id: string }`
- Validates user owns the disc
- Validates disc has a QR code linked
- Removes QR code from disc (sets `qr_code_id` to null)
- Deletes QR code from `qr_codes` table
- Returns updated disc info

## Test Plan
- [x] Unit tests for all error cases (401, 403, 400, 405)
- [x] Unit test for successful unlink and deletion
- [ ] Integration test with mobile app

🤖 Generated with [Claude Code](https://claude.com/claude-code)