### PR TITLE
feat: add sticker order management endpoints

### DIFF
--- a/supabase/functions/get-sticker-order/index.test.ts
+++ b/supabase/functions/get-sticker-order/index.test.ts
@@ -1,0 +1,272 @@
+import { assertEquals, assertExists } from 'https://deno.land/std@0.192.0/testing/asserts.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const FUNCTION_URL = Deno.env.get('FUNCTION_URL') || 'http://localhost:54321/functions/v1/get-sticker-order';
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL') || 'http://localhost:54321';
+const SUPABASE_ANON_KEY =
+  Deno.env.get('SUPABASE_ANON_KEY') ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0';
+const SUPABASE_SERVICE_ROLE_KEY =
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU';
+
+Deno.test('get-sticker-order: should return 405 for non-GET requests', async () => {
+  const response = await fetch(`${FUNCTION_URL}?order_id=test`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  assertEquals(response.status, 405);
+  const data = await response.json();
+  assertEquals(data.error, 'Method not allowed');
+});
+
+Deno.test('get-sticker-order: should return 401 when not authenticated', async () => {
+  const response = await fetch(`${FUNCTION_URL}?order_id=test`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  assertEquals(response.status, 401);
+  const data = await response.json();
+  assertEquals(data.error, 'Missing authorization header');
+});
+
+Deno.test('get-sticker-order: should return 400 when order_id is missing', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+    });
+
+    assertEquals(response.status, 400);
+    const data = await response.json();
+    assertEquals(data.error, 'Missing order_id parameter');
+  } finally {
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});
+
+Deno.test('get-sticker-order: should return 404 when order not found', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  try {
+    const response = await fetch(`${FUNCTION_URL}?order_id=00000000-0000-0000-0000-000000000000`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+    });
+
+    assertEquals(response.status, 404);
+    const data = await response.json();
+    assertEquals(data.error, 'Order not found');
+  } finally {
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});
+
+Deno.test('get-sticker-order: should return 403 when accessing another user order', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  // Create user 1 (will try to access)
+  const { data: user1Auth, error: user1Error } = await supabase.auth.signUp({
+    email: `user1-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (user1Error || !user1Auth.session || !user1Auth.user) {
+    throw user1Error || new Error('No session');
+  }
+
+  // Create user 2 (owns the order)
+  const { data: user2Auth, error: user2Error } = await supabase.auth.signUp({
+    email: `user2-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (user2Error || !user2Auth.user) {
+    throw user2Error || new Error('No user');
+  }
+
+  // Create shipping address for user 2
+  const { data: address } = await supabaseAdmin
+    .from('shipping_addresses')
+    .insert({
+      user_id: user2Auth.user.id,
+      name: 'User 2',
+      street_address: '123 Test St',
+      city: 'Test City',
+      state: 'TS',
+      postal_code: '12345',
+      country: 'US',
+    })
+    .select()
+    .single();
+
+  // Create order for user 2
+  const { data: order } = await supabaseAdmin
+    .from('sticker_orders')
+    .insert({
+      user_id: user2Auth.user.id,
+      shipping_address_id: address!.id,
+      quantity: 10,
+      unit_price_cents: 100,
+      total_price_cents: 1000,
+    })
+    .select()
+    .single();
+
+  try {
+    // User 1 tries to access user 2's order
+    const response = await fetch(`${FUNCTION_URL}?order_id=${order!.id}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${user1Auth.session.access_token}`,
+      },
+    });
+
+    assertEquals(response.status, 403);
+    const data = await response.json();
+    assertEquals(data.error, 'You do not have access to this order');
+  } finally {
+    await supabaseAdmin.from('sticker_orders').delete().eq('id', order!.id);
+    await supabaseAdmin.from('shipping_addresses').delete().eq('id', address!.id);
+    await supabaseAdmin.auth.admin.deleteUser(user1Auth.user.id);
+    await supabaseAdmin.auth.admin.deleteUser(user2Auth.user.id);
+  }
+});
+
+Deno.test('get-sticker-order: should return order with items and QR codes', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  // Create shipping address
+  const { data: address } = await supabaseAdmin
+    .from('shipping_addresses')
+    .insert({
+      user_id: authData.user.id,
+      name: 'Test User',
+      street_address: '123 Test St',
+      city: 'Test City',
+      state: 'TS',
+      postal_code: '12345',
+      country: 'US',
+    })
+    .select()
+    .single();
+
+  // Create QR codes
+  const { data: qr1 } = await supabaseAdmin
+    .from('qr_codes')
+    .insert({
+      short_code: `TEST${Date.now()}A`,
+      status: 'active',
+      assigned_to: authData.user.id,
+    })
+    .select()
+    .single();
+
+  const { data: qr2 } = await supabaseAdmin
+    .from('qr_codes')
+    .insert({
+      short_code: `TEST${Date.now()}B`,
+      status: 'active',
+      assigned_to: authData.user.id,
+    })
+    .select()
+    .single();
+
+  // Create order
+  const { data: order } = await supabaseAdmin
+    .from('sticker_orders')
+    .insert({
+      user_id: authData.user.id,
+      shipping_address_id: address!.id,
+      quantity: 2,
+      unit_price_cents: 100,
+      total_price_cents: 200,
+      status: 'paid',
+    })
+    .select()
+    .single();
+
+  // Create order items
+  await supabaseAdmin.from('sticker_order_items').insert([
+    { order_id: order!.id, qr_code_id: qr1!.id },
+    { order_id: order!.id, qr_code_id: qr2!.id },
+  ]);
+
+  try {
+    const response = await fetch(`${FUNCTION_URL}?order_id=${order!.id}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+    });
+
+    assertEquals(response.status, 200);
+    const data = await response.json();
+
+    assertExists(data.order);
+    assertEquals(data.order.id, order!.id);
+    assertEquals(data.order.quantity, 2);
+    assertEquals(data.order.status, 'paid');
+    assertExists(data.order.order_number);
+    assertExists(data.order.shipping_address);
+    assertEquals(data.order.shipping_address.city, 'Test City');
+    assertExists(data.order.items);
+    assertEquals(data.order.items.length, 2);
+    assertExists(data.order.items[0].qr_code);
+    assertExists(data.order.items[0].qr_code.short_code);
+  } finally {
+    await supabaseAdmin.from('sticker_order_items').delete().eq('order_id', order!.id);
+    await supabaseAdmin.from('sticker_orders').delete().eq('id', order!.id);
+    await supabaseAdmin.from('qr_codes').delete().eq('id', qr1!.id);
+    await supabaseAdmin.from('qr_codes').delete().eq('id', qr2!.id);
+    await supabaseAdmin.from('shipping_addresses').delete().eq('id', address!.id);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});

--- a/supabase/functions/get-sticker-order/index.ts
+++ b/supabase/functions/get-sticker-order/index.ts
@@ -1,0 +1,145 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+/**
+ * Get Single Sticker Order Function
+ *
+ * Returns a single sticker order with items and QR code details.
+ *
+ * GET /get-sticker-order?order_id=<uuid>
+ *
+ * Returns:
+ * - Order details with shipping address and order items (with QR codes)
+ */
+
+Deno.serve(async (req) => {
+  // Only allow GET requests
+  if (req.method !== 'GET') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Check authentication
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) {
+    return new Response(JSON.stringify({ error: 'Missing authorization header' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Get order_id from query params
+  const url = new URL(req.url);
+  const orderId = url.searchParams.get('order_id');
+
+  if (!orderId) {
+    return new Response(JSON.stringify({ error: 'Missing order_id parameter' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Create Supabase client with user's auth
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+  const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
+  const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+    global: {
+      headers: { Authorization: authHeader },
+    },
+  });
+
+  // Verify user is authenticated
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Use service role for database operations
+  const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+  const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
+
+  // Get order
+  const { data: order, error: orderError } = await supabaseAdmin
+    .from('sticker_orders')
+    .select(
+      `
+      id,
+      user_id,
+      order_number,
+      quantity,
+      unit_price_cents,
+      total_price_cents,
+      status,
+      stripe_payment_intent_id,
+      tracking_number,
+      pdf_storage_path,
+      created_at,
+      updated_at,
+      printed_at,
+      shipped_at,
+      shipping_address:shipping_addresses(
+        id,
+        name,
+        street_address,
+        street_address_2,
+        city,
+        state,
+        postal_code,
+        country
+      ),
+      items:sticker_order_items(
+        id,
+        qr_code:qr_codes(
+          id,
+          short_code
+        )
+      )
+    `
+    )
+    .eq('id', orderId)
+    .single();
+
+  if (orderError) {
+    if (orderError.code === 'PGRST116') {
+      return new Response(JSON.stringify({ error: 'Order not found' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    console.error('Failed to fetch order:', orderError);
+    return new Response(JSON.stringify({ error: 'Failed to fetch order' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Check if user owns this order
+  if (order.user_id !== user.id) {
+    return new Response(JSON.stringify({ error: 'You do not have access to this order' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Remove user_id from response
+  const { user_id: _, ...orderWithoutUserId } = order;
+
+  return new Response(
+    JSON.stringify({
+      order: orderWithoutUserId,
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
+});

--- a/supabase/functions/get-sticker-orders/index.test.ts
+++ b/supabase/functions/get-sticker-orders/index.test.ts
@@ -1,0 +1,241 @@
+import { assertEquals, assertExists } from 'https://deno.land/std@0.192.0/testing/asserts.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const FUNCTION_URL = Deno.env.get('FUNCTION_URL') || 'http://localhost:54321/functions/v1/get-sticker-orders';
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL') || 'http://localhost:54321';
+const SUPABASE_ANON_KEY =
+  Deno.env.get('SUPABASE_ANON_KEY') ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0';
+const SUPABASE_SERVICE_ROLE_KEY =
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU';
+
+Deno.test('get-sticker-orders: should return 405 for non-GET requests', async () => {
+  const response = await fetch(FUNCTION_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  assertEquals(response.status, 405);
+  const data = await response.json();
+  assertEquals(data.error, 'Method not allowed');
+});
+
+Deno.test('get-sticker-orders: should return 401 when not authenticated', async () => {
+  const response = await fetch(FUNCTION_URL, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  assertEquals(response.status, 401);
+  const data = await response.json();
+  assertEquals(data.error, 'Missing authorization header');
+});
+
+Deno.test('get-sticker-orders: should return empty array when user has no orders', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+    });
+
+    assertEquals(response.status, 200);
+    const data = await response.json();
+    assertEquals(data.orders, []);
+  } finally {
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});
+
+Deno.test('get-sticker-orders: should return user orders with shipping address', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  // Create shipping address
+  const { data: address, error: addrError } = await supabaseAdmin
+    .from('shipping_addresses')
+    .insert({
+      user_id: authData.user.id,
+      name: 'Test User',
+      street_address: '123 Test St',
+      city: 'Test City',
+      state: 'TS',
+      postal_code: '12345',
+      country: 'US',
+    })
+    .select()
+    .single();
+
+  if (addrError) throw addrError;
+
+  // Create order
+  const { data: order, error: orderError } = await supabaseAdmin
+    .from('sticker_orders')
+    .insert({
+      user_id: authData.user.id,
+      shipping_address_id: address.id,
+      quantity: 10,
+      unit_price_cents: 100,
+      total_price_cents: 1000,
+      status: 'pending_payment',
+    })
+    .select()
+    .single();
+
+  if (orderError) throw orderError;
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+    });
+
+    assertEquals(response.status, 200);
+    const data = await response.json();
+    assertEquals(data.orders.length, 1);
+    assertEquals(data.orders[0].id, order.id);
+    assertEquals(data.orders[0].quantity, 10);
+    assertEquals(data.orders[0].status, 'pending_payment');
+    assertExists(data.orders[0].order_number);
+    assertExists(data.orders[0].shipping_address);
+    assertEquals(data.orders[0].shipping_address.city, 'Test City');
+  } finally {
+    await supabaseAdmin.from('sticker_orders').delete().eq('id', order.id);
+    await supabaseAdmin.from('shipping_addresses').delete().eq('id', address.id);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});
+
+Deno.test('get-sticker-orders: should only return orders for authenticated user', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  // Create user 1
+  const { data: user1Auth, error: user1Error } = await supabase.auth.signUp({
+    email: `user1-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (user1Error || !user1Auth.session || !user1Auth.user) {
+    throw user1Error || new Error('No session');
+  }
+
+  // Create user 2
+  const { data: user2Auth, error: user2Error } = await supabase.auth.signUp({
+    email: `user2-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (user2Error || !user2Auth.user) {
+    throw user2Error || new Error('No user');
+  }
+
+  // Create shipping addresses
+  const { data: addr1 } = await supabaseAdmin
+    .from('shipping_addresses')
+    .insert({
+      user_id: user1Auth.user.id,
+      name: 'User 1',
+      street_address: '123 Test St',
+      city: 'City 1',
+      state: 'TS',
+      postal_code: '12345',
+      country: 'US',
+    })
+    .select()
+    .single();
+
+  const { data: addr2 } = await supabaseAdmin
+    .from('shipping_addresses')
+    .insert({
+      user_id: user2Auth.user.id,
+      name: 'User 2',
+      street_address: '456 Other St',
+      city: 'City 2',
+      state: 'TS',
+      postal_code: '67890',
+      country: 'US',
+    })
+    .select()
+    .single();
+
+  // Create orders for both users
+  const { data: order1 } = await supabaseAdmin
+    .from('sticker_orders')
+    .insert({
+      user_id: user1Auth.user.id,
+      shipping_address_id: addr1!.id,
+      quantity: 5,
+      unit_price_cents: 100,
+      total_price_cents: 500,
+    })
+    .select()
+    .single();
+
+  const { data: order2 } = await supabaseAdmin
+    .from('sticker_orders')
+    .insert({
+      user_id: user2Auth.user.id,
+      shipping_address_id: addr2!.id,
+      quantity: 15,
+      unit_price_cents: 100,
+      total_price_cents: 1500,
+    })
+    .select()
+    .single();
+
+  try {
+    // User 1 should only see their order
+    const response = await fetch(FUNCTION_URL, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${user1Auth.session.access_token}`,
+      },
+    });
+
+    assertEquals(response.status, 200);
+    const data = await response.json();
+    assertEquals(data.orders.length, 1);
+    assertEquals(data.orders[0].id, order1!.id);
+    assertEquals(data.orders[0].quantity, 5);
+  } finally {
+    await supabaseAdmin.from('sticker_orders').delete().eq('id', order1!.id);
+    await supabaseAdmin.from('sticker_orders').delete().eq('id', order2!.id);
+    await supabaseAdmin.from('shipping_addresses').delete().eq('id', addr1!.id);
+    await supabaseAdmin.from('shipping_addresses').delete().eq('id', addr2!.id);
+    await supabaseAdmin.auth.admin.deleteUser(user1Auth.user.id);
+    await supabaseAdmin.auth.admin.deleteUser(user2Auth.user.id);
+  }
+});

--- a/supabase/functions/get-sticker-orders/index.ts
+++ b/supabase/functions/get-sticker-orders/index.ts
@@ -1,0 +1,107 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+/**
+ * Get Sticker Orders Function
+ *
+ * Returns all sticker orders for the authenticated user.
+ *
+ * GET /get-sticker-orders
+ *
+ * Returns:
+ * - Array of orders with shipping address info
+ */
+
+Deno.serve(async (req) => {
+  // Only allow GET requests
+  if (req.method !== 'GET') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Check authentication
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) {
+    return new Response(JSON.stringify({ error: 'Missing authorization header' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Create Supabase client with user's auth
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+  const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
+  const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+    global: {
+      headers: { Authorization: authHeader },
+    },
+  });
+
+  // Verify user is authenticated
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Use service role for database operations
+  const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+  const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
+
+  // Get user's orders with shipping addresses
+  const { data: orders, error: ordersError } = await supabaseAdmin
+    .from('sticker_orders')
+    .select(
+      `
+      id,
+      order_number,
+      quantity,
+      unit_price_cents,
+      total_price_cents,
+      status,
+      tracking_number,
+      created_at,
+      updated_at,
+      printed_at,
+      shipped_at,
+      shipping_address:shipping_addresses(
+        id,
+        name,
+        street_address,
+        street_address_2,
+        city,
+        state,
+        postal_code,
+        country
+      )
+    `
+    )
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: false });
+
+  if (ordersError) {
+    console.error('Failed to fetch orders:', ordersError);
+    return new Response(JSON.stringify({ error: 'Failed to fetch orders' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  return new Response(
+    JSON.stringify({
+      orders: orders || [],
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
+});

--- a/supabase/functions/update-order-status/index.test.ts
+++ b/supabase/functions/update-order-status/index.test.ts
@@ -1,0 +1,373 @@
+import { assertEquals, assertExists } from 'https://deno.land/std@0.192.0/testing/asserts.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const FUNCTION_URL = Deno.env.get('FUNCTION_URL') || 'http://localhost:54321/functions/v1/update-order-status';
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL') || 'http://localhost:54321';
+const SUPABASE_ANON_KEY =
+  Deno.env.get('SUPABASE_ANON_KEY') ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0';
+const SUPABASE_SERVICE_ROLE_KEY =
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU';
+
+Deno.test('update-order-status: should return 405 for non-POST requests', async () => {
+  const response = await fetch(FUNCTION_URL, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  assertEquals(response.status, 405);
+  const data = await response.json();
+  assertEquals(data.error, 'Method not allowed');
+});
+
+Deno.test('update-order-status: should return 400 when printer_token is missing', async () => {
+  const response = await fetch(FUNCTION_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ status: 'printed' }),
+  });
+
+  assertEquals(response.status, 400);
+  const data = await response.json();
+  assertEquals(data.error, 'Missing required field: printer_token');
+});
+
+Deno.test('update-order-status: should return 400 when status is missing', async () => {
+  const response = await fetch(FUNCTION_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ printer_token: '00000000-0000-0000-0000-000000000000' }),
+  });
+
+  assertEquals(response.status, 400);
+  const data = await response.json();
+  assertEquals(data.error, 'Missing required field: status');
+});
+
+Deno.test('update-order-status: should return 400 when status is invalid', async () => {
+  const response = await fetch(FUNCTION_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      printer_token: '00000000-0000-0000-0000-000000000000',
+      status: 'invalid_status',
+    }),
+  });
+
+  assertEquals(response.status, 400);
+  const data = await response.json();
+  assertEquals(data.error, 'Invalid status');
+});
+
+Deno.test('update-order-status: should return 404 when order not found by printer_token', async () => {
+  const response = await fetch(FUNCTION_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      printer_token: '00000000-0000-0000-0000-000000000000',
+      status: 'printed',
+    }),
+  });
+
+  assertEquals(response.status, 404);
+  const data = await response.json();
+  assertEquals(data.error, 'Order not found');
+});
+
+Deno.test('update-order-status: should update order status to printed', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.user) {
+    throw signUpError || new Error('No user');
+  }
+
+  // Create shipping address
+  const { data: address } = await supabaseAdmin
+    .from('shipping_addresses')
+    .insert({
+      user_id: authData.user.id,
+      name: 'Test User',
+      street_address: '123 Test St',
+      city: 'Test City',
+      state: 'TS',
+      postal_code: '12345',
+      country: 'US',
+    })
+    .select()
+    .single();
+
+  // Create order with paid status
+  const { data: order } = await supabaseAdmin
+    .from('sticker_orders')
+    .insert({
+      user_id: authData.user.id,
+      shipping_address_id: address!.id,
+      quantity: 5,
+      unit_price_cents: 100,
+      total_price_cents: 500,
+      status: 'paid',
+    })
+    .select()
+    .single();
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        printer_token: order!.printer_token,
+        status: 'printed',
+      }),
+    });
+
+    assertEquals(response.status, 200);
+    const data = await response.json();
+    assertEquals(data.success, true);
+    assertEquals(data.order.status, 'printed');
+    assertExists(data.order.printed_at);
+
+    // Verify in database
+    const { data: updatedOrder } = await supabaseAdmin
+      .from('sticker_orders')
+      .select()
+      .eq('id', order!.id)
+      .single();
+
+    assertEquals(updatedOrder?.status, 'printed');
+    assertExists(updatedOrder?.printed_at);
+  } finally {
+    await supabaseAdmin.from('sticker_orders').delete().eq('id', order!.id);
+    await supabaseAdmin.from('shipping_addresses').delete().eq('id', address!.id);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});
+
+Deno.test('update-order-status: should update order status to shipped with tracking number', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.user) {
+    throw signUpError || new Error('No user');
+  }
+
+  // Create shipping address
+  const { data: address } = await supabaseAdmin
+    .from('shipping_addresses')
+    .insert({
+      user_id: authData.user.id,
+      name: 'Test User',
+      street_address: '123 Test St',
+      city: 'Test City',
+      state: 'TS',
+      postal_code: '12345',
+      country: 'US',
+    })
+    .select()
+    .single();
+
+  // Create order with printed status
+  const { data: order } = await supabaseAdmin
+    .from('sticker_orders')
+    .insert({
+      user_id: authData.user.id,
+      shipping_address_id: address!.id,
+      quantity: 5,
+      unit_price_cents: 100,
+      total_price_cents: 500,
+      status: 'printed',
+      printed_at: new Date().toISOString(),
+    })
+    .select()
+    .single();
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        printer_token: order!.printer_token,
+        status: 'shipped',
+        tracking_number: '1Z999AA10123456784',
+      }),
+    });
+
+    assertEquals(response.status, 200);
+    const data = await response.json();
+    assertEquals(data.success, true);
+    assertEquals(data.order.status, 'shipped');
+    assertEquals(data.order.tracking_number, '1Z999AA10123456784');
+    assertExists(data.order.shipped_at);
+
+    // Verify in database
+    const { data: updatedOrder } = await supabaseAdmin
+      .from('sticker_orders')
+      .select()
+      .eq('id', order!.id)
+      .single();
+
+    assertEquals(updatedOrder?.status, 'shipped');
+    assertEquals(updatedOrder?.tracking_number, '1Z999AA10123456784');
+    assertExists(updatedOrder?.shipped_at);
+  } finally {
+    await supabaseAdmin.from('sticker_orders').delete().eq('id', order!.id);
+    await supabaseAdmin.from('shipping_addresses').delete().eq('id', address!.id);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});
+
+Deno.test('update-order-status: should require tracking_number when setting status to shipped', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.user) {
+    throw signUpError || new Error('No user');
+  }
+
+  // Create shipping address
+  const { data: address } = await supabaseAdmin
+    .from('shipping_addresses')
+    .insert({
+      user_id: authData.user.id,
+      name: 'Test User',
+      street_address: '123 Test St',
+      city: 'Test City',
+      state: 'TS',
+      postal_code: '12345',
+      country: 'US',
+    })
+    .select()
+    .single();
+
+  // Create order with printed status
+  const { data: order } = await supabaseAdmin
+    .from('sticker_orders')
+    .insert({
+      user_id: authData.user.id,
+      shipping_address_id: address!.id,
+      quantity: 5,
+      unit_price_cents: 100,
+      total_price_cents: 500,
+      status: 'printed',
+    })
+    .select()
+    .single();
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        printer_token: order!.printer_token,
+        status: 'shipped',
+        // Missing tracking_number
+      }),
+    });
+
+    assertEquals(response.status, 400);
+    const data = await response.json();
+    assertEquals(data.error, 'tracking_number is required when marking as shipped');
+  } finally {
+    await supabaseAdmin.from('sticker_orders').delete().eq('id', order!.id);
+    await supabaseAdmin.from('shipping_addresses').delete().eq('id', address!.id);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});
+
+Deno.test('update-order-status: should reject invalid status transitions', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.user) {
+    throw signUpError || new Error('No user');
+  }
+
+  // Create shipping address
+  const { data: address } = await supabaseAdmin
+    .from('shipping_addresses')
+    .insert({
+      user_id: authData.user.id,
+      name: 'Test User',
+      street_address: '123 Test St',
+      city: 'Test City',
+      state: 'TS',
+      postal_code: '12345',
+      country: 'US',
+    })
+    .select()
+    .single();
+
+  // Create order with pending_payment status (not yet paid)
+  const { data: order } = await supabaseAdmin
+    .from('sticker_orders')
+    .insert({
+      user_id: authData.user.id,
+      shipping_address_id: address!.id,
+      quantity: 5,
+      unit_price_cents: 100,
+      total_price_cents: 500,
+      status: 'pending_payment',
+    })
+    .select()
+    .single();
+
+  try {
+    // Try to mark as shipped directly (skipping paid, processing, printed)
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        printer_token: order!.printer_token,
+        status: 'shipped',
+        tracking_number: '1Z999AA10123456784',
+      }),
+    });
+
+    assertEquals(response.status, 400);
+    const data = await response.json();
+    assertEquals(data.error, 'Invalid status transition from pending_payment to shipped');
+  } finally {
+    await supabaseAdmin.from('sticker_orders').delete().eq('id', order!.id);
+    await supabaseAdmin.from('shipping_addresses').delete().eq('id', address!.id);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});

--- a/supabase/functions/update-order-status/index.ts
+++ b/supabase/functions/update-order-status/index.ts
@@ -1,0 +1,173 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+/**
+ * Update Order Status Function
+ *
+ * Unauthenticated endpoint to update sticker order status.
+ * Uses printer_token for authentication (sent via email links).
+ *
+ * POST /update-order-status
+ * Body: {
+ *   printer_token: string,
+ *   status: 'processing' | 'printed' | 'shipped' | 'delivered',
+ *   tracking_number?: string (required when status is 'shipped')
+ * }
+ *
+ * Returns:
+ * - Updated order details
+ */
+
+// Valid statuses that can be set via this endpoint
+const VALID_STATUSES = ['processing', 'printed', 'shipped', 'delivered'];
+
+// Valid status transitions
+const STATUS_TRANSITIONS: Record<string, string[]> = {
+  pending_payment: [], // Can't transition from pending_payment via this endpoint
+  paid: ['processing', 'printed'], // Can go to processing or skip to printed
+  processing: ['printed'],
+  printed: ['shipped'],
+  shipped: ['delivered'],
+  delivered: [], // Terminal state
+  cancelled: [], // Terminal state
+};
+
+Deno.serve(async (req) => {
+  // Only allow POST requests
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Parse request body
+  let body;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const { printer_token, status, tracking_number } = body;
+
+  // Validate required fields
+  if (!printer_token) {
+    return new Response(JSON.stringify({ error: 'Missing required field: printer_token' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (!status) {
+    return new Response(JSON.stringify({ error: 'Missing required field: status' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Validate status value
+  if (!VALID_STATUSES.includes(status)) {
+    return new Response(JSON.stringify({ error: 'Invalid status' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Require tracking_number for shipped status
+  if (status === 'shipped' && !tracking_number) {
+    return new Response(JSON.stringify({ error: 'tracking_number is required when marking as shipped' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Use service role for database operations
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+  const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+  const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
+
+  // Find order by printer_token
+  const { data: order, error: orderError } = await supabaseAdmin
+    .from('sticker_orders')
+    .select('id, status, order_number')
+    .eq('printer_token', printer_token)
+    .single();
+
+  if (orderError || !order) {
+    return new Response(JSON.stringify({ error: 'Order not found' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Validate status transition
+  const allowedTransitions = STATUS_TRANSITIONS[order.status] || [];
+  if (!allowedTransitions.includes(status)) {
+    return new Response(
+      JSON.stringify({
+        error: `Invalid status transition from ${order.status} to ${status}`,
+      }),
+      {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  }
+
+  // Build update object
+  const updateData: Record<string, unknown> = {
+    status,
+    updated_at: new Date().toISOString(),
+  };
+
+  // Set timestamp fields based on status
+  if (status === 'printed') {
+    updateData.printed_at = new Date().toISOString();
+  } else if (status === 'shipped') {
+    updateData.shipped_at = new Date().toISOString();
+    updateData.tracking_number = tracking_number;
+  }
+
+  // Update order
+  const { data: updatedOrder, error: updateError } = await supabaseAdmin
+    .from('sticker_orders')
+    .update(updateData)
+    .eq('id', order.id)
+    .select(
+      `
+      id,
+      order_number,
+      status,
+      tracking_number,
+      printed_at,
+      shipped_at,
+      updated_at
+    `
+    )
+    .single();
+
+  if (updateError) {
+    console.error('Failed to update order:', updateError);
+    return new Response(JSON.stringify({ error: 'Failed to update order status' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // TODO: Send push notification to user about status change
+
+  return new Response(
+    JSON.stringify({
+      success: true,
+      order: updatedOrder,
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- Add `get-sticker-orders` endpoint to list user's sticker orders with shipping addresses
- Add `get-sticker-order` endpoint to get single order with items and QR code details
- Add `update-order-status` endpoint for printer/fulfillment to update order status via token
  - Validates allowed status transitions (paid → processing → printed → shipped → delivered)
  - Requires tracking number when marking as shipped
  - Sets `printed_at` and `shipped_at` timestamps automatically

## Test plan
- [ ] get-sticker-orders returns 405 for non-GET requests
- [ ] get-sticker-orders returns 401 when not authenticated
- [ ] get-sticker-orders returns empty array when user has no orders
- [ ] get-sticker-orders returns orders with shipping address info
- [ ] get-sticker-orders only returns orders for authenticated user
- [ ] get-sticker-order returns 404 for non-existent order
- [ ] get-sticker-order returns 403 when accessing another user's order
- [ ] get-sticker-order returns order with items and QR codes
- [ ] update-order-status validates printer_token
- [ ] update-order-status validates status transitions
- [ ] update-order-status requires tracking_number for shipped status
- [ ] update-order-status sets timestamps correctly

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)