### PR TITLE
feat: add Stripe payment integration for sticker orders

### DIFF
--- a/supabase/functions/create-sticker-order/index.test.ts
+++ b/supabase/functions/create-sticker-order/index.test.ts
@@ -1,0 +1,311 @@
+import { assertEquals, assertExists } from 'https://deno.land/std@0.192.0/testing/asserts.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const FUNCTION_URL = Deno.env.get('FUNCTION_URL') || 'http://localhost:54321/functions/v1/create-sticker-order';
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL') || 'http://localhost:54321';
+const SUPABASE_ANON_KEY =
+  Deno.env.get('SUPABASE_ANON_KEY') ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0';
+const SUPABASE_SERVICE_ROLE_KEY =
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU';
+
+Deno.test('create-sticker-order: should return 405 for non-POST requests', async () => {
+  const response = await fetch(FUNCTION_URL, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  assertEquals(response.status, 405);
+  const data = await response.json();
+  assertEquals(data.error, 'Method not allowed');
+});
+
+Deno.test('create-sticker-order: should return 401 when not authenticated', async () => {
+  const response = await fetch(FUNCTION_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ quantity: 10 }),
+  });
+
+  assertEquals(response.status, 401);
+  const data = await response.json();
+  assertEquals(data.error, 'Missing authorization header');
+});
+
+Deno.test('create-sticker-order: should return 400 when quantity is missing', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({}),
+    });
+
+    assertEquals(response.status, 400);
+    const data = await response.json();
+    assertEquals(data.error, 'Missing required field: quantity');
+  } finally {
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});
+
+Deno.test('create-sticker-order: should return 400 when quantity is invalid', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({ quantity: 0 }),
+    });
+
+    assertEquals(response.status, 400);
+    const data = await response.json();
+    assertEquals(data.error, 'Quantity must be at least 1');
+  } finally {
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});
+
+Deno.test('create-sticker-order: should return 400 when shipping_address is missing', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({ quantity: 10 }),
+    });
+
+    assertEquals(response.status, 400);
+    const data = await response.json();
+    assertEquals(data.error, 'Missing required field: shipping_address');
+  } finally {
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});
+
+Deno.test('create-sticker-order: should return 400 when shipping_address fields are incomplete', async () => {
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({
+        quantity: 10,
+        shipping_address: {
+          name: 'Test User',
+          // Missing street_address, city, state, postal_code
+        },
+      }),
+    });
+
+    assertEquals(response.status, 400);
+    const data = await response.json();
+    assertEquals(data.error, 'Missing shipping address field: street_address');
+  } finally {
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});
+
+Deno.test('create-sticker-order: should create order and return checkout URL', async () => {
+  // Note: This test requires STRIPE_SECRET_KEY to be set
+  // In local dev without Stripe, this will fail - that's expected
+  const stripeKey = Deno.env.get('STRIPE_SECRET_KEY');
+  if (!stripeKey) {
+    console.log('Skipping Stripe checkout test - STRIPE_SECRET_KEY not set');
+    return;
+  }
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({
+        quantity: 10,
+        shipping_address: {
+          name: 'Test User',
+          street_address: '123 Test St',
+          city: 'Test City',
+          state: 'TS',
+          postal_code: '12345',
+          country: 'US',
+        },
+      }),
+    });
+
+    assertEquals(response.status, 200);
+    const data = await response.json();
+    assertExists(data.checkout_url);
+    assertExists(data.order_id);
+    assertExists(data.order_number);
+
+    // Verify order was created in database
+    const { data: order } = await supabaseAdmin
+      .from('sticker_orders')
+      .select('*')
+      .eq('id', data.order_id)
+      .single();
+
+    assertExists(order);
+    assertEquals(order?.quantity, 10);
+    assertEquals(order?.status, 'pending_payment');
+    assertExists(order?.stripe_checkout_session_id);
+
+    // Cleanup
+    await supabaseAdmin.from('sticker_orders').delete().eq('id', data.order_id);
+    const { data: addr } = await supabaseAdmin
+      .from('shipping_addresses')
+      .select('id')
+      .eq('user_id', authData.user.id)
+      .single();
+    if (addr) {
+      await supabaseAdmin.from('shipping_addresses').delete().eq('id', addr.id);
+    }
+  } finally {
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});
+
+Deno.test('create-sticker-order: should use existing shipping address if provided', async () => {
+  const stripeKey = Deno.env.get('STRIPE_SECRET_KEY');
+  if (!stripeKey) {
+    console.log('Skipping Stripe checkout test - STRIPE_SECRET_KEY not set');
+    return;
+  }
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: authData, error: signUpError } = await supabase.auth.signUp({
+    email: `test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+  });
+
+  if (signUpError || !authData.session || !authData.user) {
+    throw signUpError || new Error('No session');
+  }
+
+  // Create shipping address first
+  const { data: address } = await supabaseAdmin
+    .from('shipping_addresses')
+    .insert({
+      user_id: authData.user.id,
+      name: 'Existing Address',
+      street_address: '456 Existing St',
+      city: 'Existing City',
+      state: 'EX',
+      postal_code: '67890',
+      country: 'US',
+    })
+    .select()
+    .single();
+
+  try {
+    const response = await fetch(FUNCTION_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${authData.session.access_token}`,
+      },
+      body: JSON.stringify({
+        quantity: 5,
+        shipping_address_id: address!.id,
+      }),
+    });
+
+    assertEquals(response.status, 200);
+    const data = await response.json();
+    assertExists(data.checkout_url);
+    assertExists(data.order_id);
+
+    // Verify order uses the existing address
+    const { data: order } = await supabaseAdmin
+      .from('sticker_orders')
+      .select('shipping_address_id')
+      .eq('id', data.order_id)
+      .single();
+
+    assertEquals(order?.shipping_address_id, address!.id);
+
+    // Cleanup
+    await supabaseAdmin.from('sticker_orders').delete().eq('id', data.order_id);
+  } finally {
+    await supabaseAdmin.from('shipping_addresses').delete().eq('id', address!.id);
+    await supabaseAdmin.auth.admin.deleteUser(authData.user.id);
+  }
+});

--- a/supabase/functions/create-sticker-order/index.ts
+++ b/supabase/functions/create-sticker-order/index.ts
@@ -1,0 +1,288 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import Stripe from 'https://esm.sh/stripe@14.21.0?target=deno';
+
+/**
+ * Create Sticker Order Function
+ *
+ * Creates a new sticker order and initiates Stripe Checkout.
+ *
+ * POST /create-sticker-order
+ * Body: {
+ *   quantity: number,
+ *   shipping_address_id?: string (use existing address)
+ *   shipping_address?: {
+ *     name: string,
+ *     street_address: string,
+ *     street_address_2?: string,
+ *     city: string,
+ *     state: string,
+ *     postal_code: string,
+ *     country?: string
+ *   }
+ * }
+ *
+ * Returns:
+ * - checkout_url: Stripe Checkout URL
+ * - order_id: Created order ID
+ * - order_number: Generated order number
+ */
+
+// Price per sticker in cents
+const UNIT_PRICE_CENTS = 100; // $1.00 per sticker
+
+interface ShippingAddress {
+  name: string;
+  street_address: string;
+  street_address_2?: string;
+  city: string;
+  state: string;
+  postal_code: string;
+  country?: string;
+}
+
+const REQUIRED_ADDRESS_FIELDS = ['name', 'street_address', 'city', 'state', 'postal_code'];
+
+Deno.serve(async (req) => {
+  // Only allow POST requests
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Check authentication
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader) {
+    return new Response(JSON.stringify({ error: 'Missing authorization header' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Parse request body
+  let body;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const { quantity, shipping_address_id, shipping_address } = body;
+
+  // Validate quantity
+  if (quantity === undefined || quantity === null) {
+    return new Response(JSON.stringify({ error: 'Missing required field: quantity' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  if (typeof quantity !== 'number' || quantity < 1) {
+    return new Response(JSON.stringify({ error: 'Quantity must be at least 1' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Validate shipping address
+  if (!shipping_address_id && !shipping_address) {
+    return new Response(JSON.stringify({ error: 'Missing required field: shipping_address' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // If shipping_address provided, validate required fields
+  if (shipping_address) {
+    for (const field of REQUIRED_ADDRESS_FIELDS) {
+      if (!shipping_address[field]) {
+        return new Response(JSON.stringify({ error: `Missing shipping address field: ${field}` }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+    }
+  }
+
+  // Create Supabase client with user's auth
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+  const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
+  const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+    global: {
+      headers: { Authorization: authHeader },
+    },
+  });
+
+  // Verify user is authenticated
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Use service role for database operations
+  const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+  const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
+
+  let addressId = shipping_address_id;
+
+  // If new address provided, create it
+  if (shipping_address && !shipping_address_id) {
+    const addressData: ShippingAddress & { user_id: string } = {
+      user_id: user.id,
+      name: shipping_address.name,
+      street_address: shipping_address.street_address,
+      street_address_2: shipping_address.street_address_2,
+      city: shipping_address.city,
+      state: shipping_address.state,
+      postal_code: shipping_address.postal_code,
+      country: shipping_address.country || 'US',
+    };
+
+    const { data: newAddress, error: addressError } = await supabaseAdmin
+      .from('shipping_addresses')
+      .insert(addressData)
+      .select()
+      .single();
+
+    if (addressError) {
+      console.error('Failed to create shipping address:', addressError);
+      return new Response(JSON.stringify({ error: 'Failed to create shipping address' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    addressId = newAddress.id;
+  } else if (shipping_address_id) {
+    // Verify the address belongs to the user
+    const { data: existingAddress, error: addressError } = await supabaseAdmin
+      .from('shipping_addresses')
+      .select('id')
+      .eq('id', shipping_address_id)
+      .eq('user_id', user.id)
+      .single();
+
+    if (addressError || !existingAddress) {
+      return new Response(JSON.stringify({ error: 'Shipping address not found' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+  }
+
+  // Calculate total
+  const totalPriceCents = quantity * UNIT_PRICE_CENTS;
+
+  // Create order
+  const { data: order, error: orderError } = await supabaseAdmin
+    .from('sticker_orders')
+    .insert({
+      user_id: user.id,
+      shipping_address_id: addressId,
+      quantity,
+      unit_price_cents: UNIT_PRICE_CENTS,
+      total_price_cents: totalPriceCents,
+      status: 'pending_payment',
+    })
+    .select()
+    .single();
+
+  if (orderError) {
+    console.error('Failed to create order:', orderError);
+    return new Response(JSON.stringify({ error: 'Failed to create order' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Initialize Stripe
+  const stripeSecretKey = Deno.env.get('STRIPE_SECRET_KEY');
+  if (!stripeSecretKey) {
+    console.error('STRIPE_SECRET_KEY not configured');
+    // Delete the order since we can't create checkout
+    await supabaseAdmin.from('sticker_orders').delete().eq('id', order.id);
+    return new Response(JSON.stringify({ error: 'Payment processing not configured' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const stripe = new Stripe(stripeSecretKey, {
+    apiVersion: '2023-10-16',
+  });
+
+  // Get app URLs from environment
+  const appUrl = Deno.env.get('APP_URL') || 'https://aceback.app';
+
+  try {
+    // Create Stripe Checkout session
+    const session = await stripe.checkout.sessions.create({
+      payment_method_types: ['card'],
+      line_items: [
+        {
+          price_data: {
+            currency: 'usd',
+            product_data: {
+              name: 'AceBack QR Code Stickers',
+              description: `Pack of ${quantity} QR code sticker${quantity > 1 ? 's' : ''}`,
+            },
+            unit_amount: UNIT_PRICE_CENTS,
+          },
+          quantity,
+        },
+      ],
+      mode: 'payment',
+      success_url: `${appUrl}/orders/${order.id}?status=success`,
+      cancel_url: `${appUrl}/orders/${order.id}?status=cancelled`,
+      metadata: {
+        order_id: order.id,
+        order_number: order.order_number,
+      },
+      customer_email: user.email,
+    });
+
+    // Update order with Stripe session ID
+    const { error: updateError } = await supabaseAdmin
+      .from('sticker_orders')
+      .update({
+        stripe_checkout_session_id: session.id,
+      })
+      .eq('id', order.id);
+
+    if (updateError) {
+      console.error('Failed to update order with session ID:', updateError);
+    }
+
+    return new Response(
+      JSON.stringify({
+        checkout_url: session.url,
+        order_id: order.id,
+        order_number: order.order_number,
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  } catch (stripeError) {
+    console.error('Stripe error:', stripeError);
+    // Delete the order since checkout failed
+    await supabaseAdmin.from('sticker_orders').delete().eq('id', order.id);
+    return new Response(JSON.stringify({ error: 'Failed to create checkout session' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/functions/stripe-webhook/index.test.ts
+++ b/supabase/functions/stripe-webhook/index.test.ts
@@ -1,0 +1,132 @@
+import { assertEquals, assertExists } from 'https://deno.land/std@0.192.0/testing/asserts.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const FUNCTION_URL = Deno.env.get('FUNCTION_URL') || 'http://localhost:54321/functions/v1/stripe-webhook';
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL') || 'http://localhost:54321';
+const SUPABASE_SERVICE_ROLE_KEY =
+  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ||
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU';
+
+Deno.test('stripe-webhook: should return 405 for non-POST requests', async () => {
+  const response = await fetch(FUNCTION_URL, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+
+  assertEquals(response.status, 405);
+  const data = await response.json();
+  assertEquals(data.error, 'Method not allowed');
+});
+
+Deno.test('stripe-webhook: should return 400 when stripe-signature header is missing', async () => {
+  const response = await fetch(FUNCTION_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ type: 'test' }),
+  });
+
+  assertEquals(response.status, 400);
+  const data = await response.json();
+  assertEquals(data.error, 'Missing stripe-signature header');
+});
+
+// Note: Full webhook testing requires a valid Stripe signature
+// which requires the STRIPE_WEBHOOK_SECRET environment variable
+// These tests verify the basic request handling
+
+Deno.test('stripe-webhook: should handle checkout.session.completed event', async () => {
+  // This test would require mocking Stripe webhook signature verification
+  // In production, we'll test this with Stripe CLI: `stripe listen --forward-to localhost:54321/functions/v1/stripe-webhook`
+
+  // Skip test if webhook secret is not configured
+  const webhookSecret = Deno.env.get('STRIPE_WEBHOOK_SECRET');
+  if (!webhookSecret) {
+    console.log('Skipping webhook test - STRIPE_WEBHOOK_SECRET not set');
+    return;
+  }
+
+  // For integration testing, use Stripe CLI to send test events:
+  // stripe trigger checkout.session.completed
+  console.log('To test webhooks, use Stripe CLI:');
+  console.log('stripe listen --forward-to localhost:54321/functions/v1/stripe-webhook');
+  console.log('stripe trigger checkout.session.completed');
+});
+
+Deno.test('stripe-webhook: should update order status to paid on successful payment', async () => {
+  // This test verifies the expected behavior without actually calling Stripe
+  // It tests the database update logic
+
+  const supabaseAdmin = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  // Create a test user
+  const { data: userData, error: userError } = await supabaseAdmin.auth.admin.createUser({
+    email: `webhook-test-${Date.now()}@example.com`,
+    password: 'testpassword123',
+    email_confirm: true,
+  });
+
+  if (userError) throw userError;
+
+  // Create shipping address
+  const { data: address, error: addrError } = await supabaseAdmin
+    .from('shipping_addresses')
+    .insert({
+      user_id: userData.user.id,
+      name: 'Test User',
+      street_address: '123 Test St',
+      city: 'Test City',
+      state: 'TS',
+      postal_code: '12345',
+      country: 'US',
+    })
+    .select()
+    .single();
+
+  if (addrError) throw addrError;
+
+  // Create an order with pending_payment status
+  const testCheckoutSessionId = `cs_test_${Date.now()}`;
+  const { data: order, error: orderError } = await supabaseAdmin
+    .from('sticker_orders')
+    .insert({
+      user_id: userData.user.id,
+      shipping_address_id: address.id,
+      quantity: 10,
+      unit_price_cents: 100,
+      total_price_cents: 1000,
+      status: 'pending_payment',
+      stripe_checkout_session_id: testCheckoutSessionId,
+    })
+    .select()
+    .single();
+
+  if (orderError) throw orderError;
+
+  try {
+    // Simulate what the webhook handler would do
+    const { data: updatedOrder, error: updateError } = await supabaseAdmin
+      .from('sticker_orders')
+      .update({
+        status: 'paid',
+        stripe_payment_intent_id: 'pi_test_123',
+        updated_at: new Date().toISOString(),
+      })
+      .eq('stripe_checkout_session_id', testCheckoutSessionId)
+      .select()
+      .single();
+
+    if (updateError) throw updateError;
+
+    assertEquals(updatedOrder.status, 'paid');
+    assertExists(updatedOrder.stripe_payment_intent_id);
+  } finally {
+    // Cleanup
+    await supabaseAdmin.from('sticker_orders').delete().eq('id', order.id);
+    await supabaseAdmin.from('shipping_addresses').delete().eq('id', address.id);
+    await supabaseAdmin.auth.admin.deleteUser(userData.user.id);
+  }
+});

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -1,0 +1,174 @@
+import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import Stripe from 'https://esm.sh/stripe@14.21.0?target=deno';
+
+/**
+ * Stripe Webhook Handler
+ *
+ * Handles Stripe webhook events for payment processing.
+ *
+ * POST /stripe-webhook
+ *
+ * Events handled:
+ * - checkout.session.completed: Updates order status to 'paid'
+ * - checkout.session.expired: Updates order status to 'cancelled'
+ */
+
+// Webhook event types we handle
+const HANDLED_EVENTS = ['checkout.session.completed', 'checkout.session.expired'];
+
+Deno.serve(async (req) => {
+  // Only allow POST requests
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Get Stripe signature from header
+  const signature = req.headers.get('stripe-signature');
+  if (!signature) {
+    return new Response(JSON.stringify({ error: 'Missing stripe-signature header' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Get webhook secret
+  const webhookSecret = Deno.env.get('STRIPE_WEBHOOK_SECRET');
+  if (!webhookSecret) {
+    console.error('STRIPE_WEBHOOK_SECRET not configured');
+    return new Response(JSON.stringify({ error: 'Webhook not configured' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Get Stripe secret key
+  const stripeSecretKey = Deno.env.get('STRIPE_SECRET_KEY');
+  if (!stripeSecretKey) {
+    console.error('STRIPE_SECRET_KEY not configured');
+    return new Response(JSON.stringify({ error: 'Stripe not configured' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const stripe = new Stripe(stripeSecretKey, {
+    apiVersion: '2023-10-16',
+  });
+
+  // Get raw body for signature verification
+  const body = await req.text();
+
+  // Verify webhook signature
+  let event: Stripe.Event;
+  try {
+    event = await stripe.webhooks.constructEventAsync(body, signature, webhookSecret);
+  } catch (err) {
+    console.error('Webhook signature verification failed:', err);
+    return new Response(JSON.stringify({ error: 'Invalid signature' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Check if we handle this event type
+  if (!HANDLED_EVENTS.includes(event.type)) {
+    console.log(`Ignoring unhandled event type: ${event.type}`);
+    return new Response(JSON.stringify({ received: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // Create Supabase admin client
+  const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
+  const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
+  const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
+
+  // Handle the event
+  switch (event.type) {
+    case 'checkout.session.completed': {
+      const session = event.data.object as Stripe.Checkout.Session;
+      console.log(`Checkout session completed: ${session.id}`);
+
+      // Get order ID from metadata
+      const orderId = session.metadata?.order_id;
+      if (!orderId) {
+        console.error('No order_id in session metadata');
+        return new Response(JSON.stringify({ error: 'Missing order_id in metadata' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      // Update order status to paid
+      const { data: updatedOrder, error: updateError } = await supabaseAdmin
+        .from('sticker_orders')
+        .update({
+          status: 'paid',
+          stripe_payment_intent_id: session.payment_intent as string,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', orderId)
+        .eq('stripe_checkout_session_id', session.id)
+        .select()
+        .single();
+
+      if (updateError) {
+        console.error('Failed to update order:', updateError);
+        return new Response(JSON.stringify({ error: 'Failed to update order' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      console.log(`Order ${updatedOrder.order_number} marked as paid`);
+
+      // TODO: Trigger QR code generation
+      // TODO: Send confirmation email to user
+      // TODO: Send notification to printer
+
+      break;
+    }
+
+    case 'checkout.session.expired': {
+      const session = event.data.object as Stripe.Checkout.Session;
+      console.log(`Checkout session expired: ${session.id}`);
+
+      // Get order ID from metadata
+      const orderId = session.metadata?.order_id;
+      if (!orderId) {
+        console.error('No order_id in session metadata');
+        return new Response(JSON.stringify({ received: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      // Update order status to cancelled
+      const { error: updateError } = await supabaseAdmin
+        .from('sticker_orders')
+        .update({
+          status: 'cancelled',
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', orderId)
+        .eq('stripe_checkout_session_id', session.id)
+        .eq('status', 'pending_payment'); // Only cancel if still pending
+
+      if (updateError) {
+        console.error('Failed to cancel order:', updateError);
+      }
+
+      break;
+    }
+  }
+
+  return new Response(JSON.stringify({ received: true }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+});


### PR DESCRIPTION
## Summary
- Add `create-sticker-order` endpoint to create orders and Stripe Checkout sessions
  - Validates quantity (must be at least 1)
  - Validates shipping address (can create new or use existing)
  - Creates order in database with `pending_payment` status
  - Creates Stripe Checkout session and returns checkout URL
  - Price: $1.00 per sticker (configurable via `UNIT_PRICE_CENTS` constant)
- Add `stripe-webhook` endpoint to handle Stripe webhook events
  - Verifies Stripe webhook signature
  - Handles `checkout.session.completed`: Updates order to `paid` status
  - Handles `checkout.session.expired`: Cancels pending orders

## Environment Variables Required
- `STRIPE_SECRET_KEY`: Stripe secret API key
- `STRIPE_WEBHOOK_SECRET`: Stripe webhook endpoint secret
- `APP_URL`: Base URL for success/cancel redirects (default: https://aceback.app)

## Test plan
- [ ] create-sticker-order returns 405 for non-POST requests
- [ ] create-sticker-order returns 401 when not authenticated
- [ ] create-sticker-order returns 400 when quantity is missing or invalid
- [ ] create-sticker-order returns 400 when shipping_address is missing
- [ ] create-sticker-order validates shipping address fields
- [ ] create-sticker-order creates order and returns checkout URL (requires STRIPE_SECRET_KEY)
- [ ] create-sticker-order uses existing shipping address when provided
- [ ] stripe-webhook returns 400 when signature is missing
- [ ] stripe-webhook verifies Stripe signature
- [ ] stripe-webhook updates order to 'paid' on checkout.session.completed

## Testing Webhooks Locally
```bash
# Start Stripe CLI to forward webhooks
stripe listen --forward-to localhost:54321/functions/v1/stripe-webhook

# In another terminal, trigger test events
stripe trigger checkout.session.completed
```

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)