### PR TITLE
fix: update Stripe checkout redirect URLs

### DIFF
--- a/supabase/functions/create-sticker-order/index.ts
+++ b/supabase/functions/create-sticker-order/index.ts
@@ -226,6 +226,10 @@ Deno.serve(async (req) => {
   // Get app URLs from environment
   const appUrl = Deno.env.get('APP_URL') || 'https://aceback.app';
 
+  // For mobile, use a simple success page that closes the browser
+  const successUrl = `${appUrl}/checkout-success?order_id=${order.id}`;
+  const cancelUrl = `${appUrl}/checkout-cancel?order_id=${order.id}`;
+
   try {
     // Create Stripe Checkout session
     const session = await stripe.checkout.sessions.create({
@@ -244,8 +248,8 @@ Deno.serve(async (req) => {
         },
       ],
       mode: 'payment',
-      success_url: `${appUrl}/orders/${order.id}?status=success`,
-      cancel_url: `${appUrl}/orders/${order.id}?status=cancelled`,
+      success_url: successUrl,
+      cancel_url: cancelUrl,
       metadata: {
         order_id: order.id,
         order_number: order.order_number,


### PR DESCRIPTION
## Changes

- Updated Stripe checkout success/cancel URLs to use `/checkout-success` and `/checkout-cancel`
- These new endpoints will be handled by the web app (separate PR)
- Fixes 404 errors when users complete Stripe checkout from mobile app

## Related

- Mobile PR: #117
- Web PR: (to be created)

## Testing

1. Start mobile app and create a sticker order
2. Complete Stripe checkout with test card
3. Verify redirect no longer shows 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)