### PR TITLE
feat: update sticker dimensions to 1.5" × 2"

### DIFF
--- a/supabase/functions/generate-sticker-pdf/index.ts
+++ b/supabase/functions/generate-sticker-pdf/index.ts
@@ -19,13 +19,13 @@ import { LOGO_BASE64 } from './logo-data.ts';
  */
 
 // Sticker dimensions in points (72 points = 1 inch)
-const STICKER_WIDTH = 144; // 2 inches
+const STICKER_WIDTH = 108; // 1.5 inches
 const STICKER_HEIGHT = 144; // 2 inches
 const QR_SIZE = 85; // QR code size in points
 const MARGIN = 10;
 const PAGE_MARGIN = 36; // 0.5 inch margin
-const STICKERS_PER_ROW = 4;
-const STICKERS_PER_COL = 5;
+const STICKERS_PER_ROW = 5; // Fits 5 across with 1.5" width (5 × 108 + margins = ~600pt)
+const STICKERS_PER_COL = 5; // 25 stickers per page (was 20)
 
 // Note: PerfCutContour spot color for Roland VersaWorks
 // Currently using magenta RGB as placeholder - actual spot color


### PR DESCRIPTION
## Summary

Changes sticker dimensions from 2" × 2" (square) to 1.5" × 2" (vertical rectangle).

## Changes

- **Width**: 2" → 1.5" (144pt → 108pt)
- **Height**: Remains 2" (144pt)
- **Stickers per row**: 4 → 5
- **Stickers per page**: 20 → 25

## Benefits

- ✅ More material efficient (narrower stickers)
- ✅ 25% more stickers per sheet
- ✅ Better fit for disc placement
- ✅ Vertical format matches logo orientation

## Layout

```
┌────────────┐
│ [DISCR]    │
│            │
│ [QR CODE]  │
│            │
│ aceback.app│
└────────────┘
 1.5" × 2"
```

## Test Plan

- [ ] Generate test PDF with new dimensions
- [ ] Verify 5 stickers fit across page width
- [ ] Verify logo, QR code, and URL are properly centered
- [ ] Test print on actual sticker sheets

🤖 Generated with [Claude Code](https://claude.com/claude-code)