### PR TITLE
fix: redirect to web app for order status updates

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -498,3 +498,50 @@ entrypoint = "./functions/create-drop-off/index.ts"
 # Specifies static files to be bundled with the function. Supports glob patterns.
 # For example, if you want to serve static HTML pages in your function:
 # static_files = [ "./functions/create-drop-off/*.html" ]
+
+# Sticker order functions
+[functions.create-sticker-order]
+enabled = true
+verify_jwt = true
+entrypoint = "./functions/create-sticker-order/index.ts"
+
+[functions.get-sticker-order]
+enabled = true
+verify_jwt = true
+entrypoint = "./functions/get-sticker-order/index.ts"
+
+[functions.get-sticker-orders]
+enabled = true
+verify_jwt = true
+entrypoint = "./functions/get-sticker-orders/index.ts"
+
+[functions.generate-order-qr-codes]
+enabled = true
+verify_jwt = true
+entrypoint = "./functions/generate-order-qr-codes/index.ts"
+
+[functions.generate-sticker-pdf]
+enabled = true
+verify_jwt = true
+entrypoint = "./functions/generate-sticker-pdf/index.ts"
+
+[functions.send-order-confirmation]
+enabled = true
+verify_jwt = false
+entrypoint = "./functions/send-order-confirmation/index.ts"
+
+[functions.send-printer-notification]
+enabled = true
+verify_jwt = false
+entrypoint = "./functions/send-printer-notification/index.ts"
+
+[functions.send-order-shipped]
+enabled = true
+verify_jwt = false
+entrypoint = "./functions/send-order-shipped/index.ts"
+
+# Note: verify_jwt = false because this is accessed via email links with printer_token
+[functions.update-order-status]
+enabled = true
+verify_jwt = false
+entrypoint = "./functions/update-order-status/index.ts"


### PR DESCRIPTION
## Summary

Fixes the HTML success page displaying as raw HTML code in browsers by redirecting to a proper web page instead of returning HTML from the Edge Function.

## Problem

When clicking the "Mark as Printed" button from the email, the browser was showing the raw HTML source code instead of rendering the page properly. This is due to how Supabase Edge Functions handle Content-Type headers.

## Solution

Changed the approach to redirect to the web app instead of returning HTML:
- **Before**: Edge Function returned HTML directly (broken)
- **After**: Edge Function redirects to `https://aceback.app/order-updated`

### Changes

1. **Edge Function** (`update-order-status`):
   - GET requests now redirect to `https://aceback.app/order-updated`
   - Success: `?order=AB-xxx&status=printed`
   - Errors: `?error=Error+message`
   - POST requests unchanged (return JSON)

2. **Config** (`config.toml`):
   - Added sticker order function configs
   - Set `verify_jwt = false` for `update-order-status` (accessed via email links)

3. **Tests**:
   - Updated to test redirect behavior for GET requests
   - Added tests for error redirects

## Depends On

- acebackapp/web PR for `/order-updated` page

## Test Plan

- [ ] Create a new sticker order
- [ ] Click "Mark as Printed" button in printer email
- [ ] Should redirect to `https://aceback.app/order-updated?order=...&status=printed`
- [ ] Verify rendered success page displays correctly
- [ ] Test error case (invalid token) shows error page

🤖 Generated with [Claude Code](https://claude.com/claude-code)