### PR TITLE
feat: add ship-order form and allow optional tracking

### DIFF
--- a/supabase/functions/send-printer-notification/index.ts
+++ b/supabase/functions/send-printer-notification/index.ts
@@ -114,7 +114,8 @@ Deno.serve(async (req) => {
 
   // Generate action URLs with printer token
   const markPrintedUrl = `${API_URL}/functions/v1/update-order-status?action=mark_printed&token=${order.printer_token}`;
-  const markShippedUrl = `${API_URL}/functions/v1/update-order-status?action=mark_shipped&token=${order.printer_token}`;
+  // Ship order goes to web form (requires tracking number input)
+  const markShippedUrl = `https://aceback.app/ship-order?token=${order.printer_token}`;
 
   // Format shipping address
   const addressLines = [


### PR DESCRIPTION
## Summary

Adds a web form for marking orders as shipped and makes tracking number optional.

## Changes

### Email Link
- "Mark as Shipped" button now links to `https://aceback.app/ship-order?token=...`
- This opens a form where the printer can optionally enter a tracking number

### Status Transitions
- Now allows: `paid → shipped` and `processing → shipped` (skipping printed)
- When skipping to shipped, `printed_at` is automatically set to the current time

### Tracking Number
- Tracking is now **optional** for shipped status
- Supports shipments without tracking (e.g., first-class mail with forever stamp)

## Depends On

- acebackapp/web PR for `/ship-order` form page

## Test Plan

- [ ] Place a new sticker order
- [ ] Click "Mark as Shipped" in printer email
- [ ] Should redirect to form at aceback.app/ship-order
- [ ] Submit without tracking number - should succeed
- [ ] Submit with tracking number - should succeed and save tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)