### PR TITLE
fix: add CORS headers to update-order-status endpoint

### DIFF
--- a/supabase/functions/update-order-status/index.ts
+++ b/supabase/functions/update-order-status/index.ts
@@ -1,6 +1,13 @@
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
+// CORS headers for cross-origin requests from web app
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+};
+
 /**
  * Update Order Status Function
  *
@@ -44,11 +51,19 @@ function errorResponse(error: string, statusCode: number, isGet: boolean): Respo
   }
   return new Response(JSON.stringify({ error }), {
     status: statusCode,
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...CORS_HEADERS },
   });
 }
 
 Deno.serve(async (req) => {
+  // Handle CORS preflight requests
+  if (req.method === 'OPTIONS') {
+    return new Response(null, {
+      status: 204,
+      headers: CORS_HEADERS,
+    });
+  }
+
   let printer_token: string | undefined;
   let status: string | undefined;
   let tracking_number: string | undefined;
@@ -79,7 +94,7 @@ Deno.serve(async (req) => {
     } catch {
       return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
         status: 400,
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...CORS_HEADERS },
       });
     }
     printer_token = body.printer_token;
@@ -88,7 +103,7 @@ Deno.serve(async (req) => {
   } else {
     return new Response(JSON.stringify({ error: 'Method not allowed' }), {
       status: 405,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...CORS_HEADERS },
     });
   }
 
@@ -239,7 +254,7 @@ Deno.serve(async (req) => {
     }),
     {
       status: 200,
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...CORS_HEADERS },
     }
   );
 });


### PR DESCRIPTION
## Summary
- Add CORS headers (`Access-Control-Allow-Origin: *`, `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers`)
- Handle OPTIONS preflight requests for browser CORS checks
- Enables the `/ship-order` form on the web app to POST to this Edge Function

## Context
The ship-order form was showing "Network error. Please try again." due to browser CORS restrictions. This fix was already deployed directly and is working - this PR commits the code changes.

## Test plan
- [ ] Verify ship-order form at https://aceback.app/ship-order?token=<token> can successfully mark orders as shipped
- [ ] Verify existing GET requests (email links) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)