### PR TITLE
feat: pass shipping address to Stripe for fulfillment tracking

### DIFF
--- a/supabase/functions/get-default-address/index.test.ts
+++ b/supabase/functions/get-default-address/index.test.ts
@@ -65,9 +65,7 @@ function mockSupabaseClient(userId?: string) {
           }),
           single: () => {
             if (table === 'shipping_addresses') {
-              const address = mockShippingAddresses.find(
-                (a) => a[column as keyof MockShippingAddress] === value
-              );
+              const address = mockShippingAddresses.find((a) => a[column as keyof MockShippingAddress] === value);
               if (address) {
                 return Promise.resolve({ data: address, error: null });
               }

--- a/supabase/functions/save-default-address/index.test.ts
+++ b/supabase/functions/save-default-address/index.test.ts
@@ -64,9 +64,7 @@ function mockSupabaseClient(userId?: string) {
           }),
           single: () => {
             if (table === 'shipping_addresses') {
-              const address = mockShippingAddresses.find(
-                (a) => a[column as keyof MockShippingAddress] === value
-              );
+              const address = mockShippingAddresses.find((a) => a[column as keyof MockShippingAddress] === value);
               if (address) {
                 return Promise.resolve({ data: address, error: null });
               }
@@ -106,9 +104,7 @@ function mockSupabaseClient(userId?: string) {
           select: (_columns?: string) => ({
             single: () => {
               if (table === 'shipping_addresses') {
-                const index = mockShippingAddresses.findIndex(
-                  (a) => a[column as keyof MockShippingAddress] === value
-                );
+                const index = mockShippingAddresses.findIndex((a) => a[column as keyof MockShippingAddress] === value);
                 if (index !== -1) {
                   mockShippingAddresses[index] = {
                     ...mockShippingAddresses[index],
@@ -323,11 +319,15 @@ Deno.test('save-default-address: should create new default address for user', as
     country: 'US',
   };
 
-  const { data: address } = await supabase.from('shipping_addresses').insert({
-    user_id: userId,
-    ...body,
-    is_default: true,
-  }).select('*').single();
+  const { data: address } = await supabase
+    .from('shipping_addresses')
+    .insert({
+      user_id: userId,
+      ...body,
+      is_default: true,
+    })
+    .select('*')
+    .single();
 
   assertExists(address);
 
@@ -381,7 +381,8 @@ Deno.test('save-default-address: should update existing address when address_id 
     city: 'Austin',
   };
 
-  const { data: updatedAddress } = await supabase.from('shipping_addresses')
+  const { data: updatedAddress } = await supabase
+    .from('shipping_addresses')
     .update(updateBody)
     .eq('id', 'address-1')
     .select('*')
@@ -424,10 +425,7 @@ Deno.test('save-default-address: should return 403 when address_id belongs to an
   assertExists(authData.user);
 
   // User 1 tries to get user 2's address
-  const { data: address } = await supabase.from('shipping_addresses')
-    .select('*')
-    .eq('id', 'address-1')
-    .single();
+  const { data: address } = await supabase.from('shipping_addresses').select('*').eq('id', 'address-1').single();
 
   assertExists(address);
 
@@ -467,12 +465,16 @@ Deno.test('save-default-address: should default country to US when not provided'
     // country not provided
   };
 
-  const { data: address } = await supabase.from('shipping_addresses').insert({
-    user_id: userId,
-    ...body,
-    country: body.country || 'US', // Default to US
-    is_default: true,
-  }).select('*').single();
+  const { data: address } = await supabase
+    .from('shipping_addresses')
+    .insert({
+      user_id: userId,
+      ...body,
+      country: body.country || 'US', // Default to US
+      is_default: true,
+    })
+    .select('*')
+    .single();
 
   assertExists(address);
   assertEquals(address.country, 'US');

--- a/supabase/migrations/20251218194644_add_stripe_customer_id.sql
+++ b/supabase/migrations/20251218194644_add_stripe_customer_id.sql
@@ -1,0 +1,9 @@
+-- Add stripe_customer_id to profiles table for billing address pre-fill
+ALTER TABLE profiles
+ADD COLUMN stripe_customer_id text UNIQUE;
+
+-- Add index for faster lookups
+CREATE INDEX idx_profiles_stripe_customer_id ON profiles(stripe_customer_id)
+WHERE stripe_customer_id IS NOT NULL;
+
+COMMENT ON COLUMN profiles.stripe_customer_id IS 'Stripe Customer ID for billing address pre-fill in checkout';


### PR DESCRIPTION
## Summary
- Pre-fill billing address in Stripe Checkout using a Stripe Customer
- Shipping address is also attached to the payment intent for fulfillment tracking

## Changes
- `supabase/migrations/20251218194644_add_stripe_customer_id.sql`: Add stripe_customer_id to profiles
- `supabase/functions/create-sticker-order/index.ts`:
  - Check if user has existing Stripe Customer ID
  - Create new Stripe Customer with address on first order
  - Update customer's address on subsequent orders
  - Pass customer ID to checkout (pre-fills billing form)
  - Also attach shipping to payment_intent_data for fulfillment

## How it works
1. First order: Creates a Stripe Customer with the user's shipping address, saves the customer ID to their profile
2. Subsequent orders: Updates the existing Stripe Customer's address
3. Checkout: Passes the customer ID so Stripe pre-fills billing address from customer record

## Test plan
- [ ] First order: Billing address should be pre-filled with shipping address
- [ ] Subsequent orders: Updated address should appear in billing pre-fill
- [ ] Stripe Dashboard: Payment should show shipping info

🤖 Generated with [Claude Code](https://claude.com/claude-code)