### PR TITLE
feat: return qr_code_id for assignee in lookup-qr-code

### DIFF
--- a/supabase/functions/lookup-qr-code/index.ts
+++ b/supabase/functions/lookup-qr-code/index.ts
@@ -123,6 +123,7 @@ Deno.serve(async (req) => {
         qr_exists: true,
         qr_status: 'assigned',
         qr_code: qrCode.short_code,
+        qr_code_id: isAssignee ? qrCode.id : undefined, // Only return ID if user is assignee
         is_assignee: isAssignee,
       }),
       {


### PR DESCRIPTION
## Summary
- When lookup-qr-code returns an 'assigned' status QR code and the authenticated user is the assignee, now also return `qr_code_id` (the UUID)
- This allows the mobile app to link the QR code to a new disc when adding by scan

## Why
When users buy QR stickers and claim them (status: 'assigned'), then later scan them when adding a disc, the mobile app needs the UUID to pass to create-disc for linking.

## Changes
- Added `qr_code_id: isAssignee ? qrCode.id : undefined` to the assigned status response

## Test plan
- [x] Type check passes
- [ ] Test scanning an assigned QR code returns the qr_code_id for assignee
- [ ] Test scanning an assigned QR code does not return qr_code_id for non-assignee

🤖 Generated with [Claude Code](https://claude.com/claude-code)