### PR TITLE
fix: support separate webhook secret for Connect events

### DIFF
--- a/supabase/functions/get-connect-status/index.test.ts
+++ b/supabase/functions/get-connect-status/index.test.ts
@@ -119,7 +119,7 @@ Deno.test('get-connect-status: should return none status when user has no Connec
   authHeaderPresent = true;
 
   const supabase = mockSupabaseClient();
-  const { data: profile } = await supabase
+  const { data: _profile } = await supabase
     .from('profiles')
     .select('stripe_connect_account_id, stripe_connect_status')
     .eq('id', user.id)
@@ -161,7 +161,7 @@ Deno.test('get-connect-status: should return pending status for incomplete onboa
   authHeaderPresent = true;
 
   const supabase = mockSupabaseClient();
-  const { data: profile } = await supabase
+  const { data: _profile } = await supabase
     .from('profiles')
     .select('stripe_connect_account_id, stripe_connect_status')
     .eq('id', user.id)
@@ -202,7 +202,7 @@ Deno.test('get-connect-status: should return active status for completed onboard
   authHeaderPresent = true;
 
   const supabase = mockSupabaseClient();
-  const { data: profile } = await supabase
+  const { data: _profile } = await supabase
     .from('profiles')
     .select('stripe_connect_account_id, stripe_connect_status')
     .eq('id', user.id)

--- a/supabase/functions/get-connect-status/index.ts
+++ b/supabase/functions/get-connect-status/index.ts
@@ -128,10 +128,7 @@ Deno.serve(async (req) => {
 
     // Update cached status if changed
     if (profile.stripe_connect_status !== status) {
-      await supabaseAdmin
-        .from('profiles')
-        .update({ stripe_connect_status: status })
-        .eq('id', user.id);
+      await supabaseAdmin.from('profiles').update({ stripe_connect_status: status }).eq('id', user.id);
     }
 
     return new Response(

--- a/supabase/functions/mark-reward-paid/index.test.ts
+++ b/supabase/functions/mark-reward-paid/index.test.ts
@@ -120,13 +120,10 @@ Deno.test('mark-reward-paid: should return 400 when recovery_event_id is missing
   const body: { recovery_event_id?: string } = {};
 
   if (!body.recovery_event_id) {
-    const response = new Response(
-      JSON.stringify({ error: 'Missing required field: recovery_event_id' }),
-      {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      }
-    );
+    const response = new Response(JSON.stringify({ error: 'Missing required field: recovery_event_id' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
     assertEquals(response.status, 400);
     const data = await response.json();
     assertEquals(data.error, 'Missing required field: recovery_event_id');
@@ -140,11 +137,7 @@ Deno.test('mark-reward-paid: should return 404 when recovery event not found', a
   authHeaderPresent = true;
 
   const supabase = mockSupabaseClient();
-  const { data: recovery } = await supabase
-    .from('recovery_events')
-    .select('*')
-    .eq('id', 'non-existent-id')
-    .single();
+  const { data: recovery } = await supabase.from('recovery_events').select('*').eq('id', 'non-existent-id').single();
 
   if (!recovery) {
     const response = new Response(JSON.stringify({ error: 'Recovery event not found' }), {
@@ -177,20 +170,13 @@ Deno.test('mark-reward-paid: should return 403 when user is not finder', async (
   authHeaderPresent = true;
 
   const supabase = mockSupabaseClient();
-  const { data: recovery } = await supabase
-    .from('recovery_events')
-    .select('*')
-    .eq('id', 'recovery-123')
-    .single();
+  const { data: recovery } = await supabase.from('recovery_events').select('*').eq('id', 'recovery-123').single();
 
   if (recovery && recovery.finder_id !== currentUserId) {
-    const response = new Response(
-      JSON.stringify({ error: 'Only the finder can mark the reward as received' }),
-      {
-        status: 403,
-        headers: { 'Content-Type': 'application/json' },
-      }
-    );
+    const response = new Response(JSON.stringify({ error: 'Only the finder can mark the reward as received' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
     assertEquals(response.status, 403);
     const data = await response.json();
     assertEquals(data.error, 'Only the finder can mark the reward as received');
@@ -215,11 +201,7 @@ Deno.test('mark-reward-paid: should return 400 when recovery is not in recovered
   authHeaderPresent = true;
 
   const supabase = mockSupabaseClient();
-  const { data: recovery } = await supabase
-    .from('recovery_events')
-    .select('*')
-    .eq('id', 'recovery-123')
-    .single();
+  const { data: recovery } = await supabase.from('recovery_events').select('*').eq('id', 'recovery-123').single();
 
   if (recovery && recovery.status !== 'recovered') {
     const response = new Response(
@@ -253,20 +235,13 @@ Deno.test('mark-reward-paid: should return 400 when disc has no reward', async (
   authHeaderPresent = true;
 
   const supabase = mockSupabaseClient();
-  const { data: recovery } = await supabase
-    .from('recovery_events')
-    .select('*')
-    .eq('id', 'recovery-123')
-    .single();
+  const { data: recovery } = await supabase.from('recovery_events').select('*').eq('id', 'recovery-123').single();
 
   if (recovery?.disc && (recovery.disc.reward_amount === null || recovery.disc.reward_amount <= 0)) {
-    const response = new Response(
-      JSON.stringify({ error: 'This disc does not have a reward set' }),
-      {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      }
-    );
+    const response = new Response(JSON.stringify({ error: 'This disc does not have a reward set' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
     assertEquals(response.status, 400);
     const data = await response.json();
     assertEquals(data.error, 'This disc does not have a reward set');
@@ -292,11 +267,7 @@ Deno.test('mark-reward-paid: should return success when already marked as paid',
   authHeaderPresent = true;
 
   const supabase = mockSupabaseClient();
-  const { data: recovery } = await supabase
-    .from('recovery_events')
-    .select('*')
-    .eq('id', 'recovery-123')
-    .single();
+  const { data: recovery } = await supabase.from('recovery_events').select('*').eq('id', 'recovery-123').single();
 
   if (recovery?.reward_paid_at) {
     const response = new Response(
@@ -339,10 +310,7 @@ Deno.test('mark-reward-paid: finder can successfully mark reward as received', a
 
   // Simulate marking as paid
   const now = new Date().toISOString();
-  await supabase
-    .from('recovery_events')
-    .update({ reward_paid_at: now, updated_at: now })
-    .eq('id', 'recovery-123');
+  await supabase.from('recovery_events').update({ reward_paid_at: now, updated_at: now }).eq('id', 'recovery-123');
 
   // Verify it was updated
   const recovery = mockRecoveryEvents.find((r) => r.id === 'recovery-123');

--- a/supabase/functions/mark-reward-paid/index.ts
+++ b/supabase/functions/mark-reward-paid/index.ts
@@ -104,24 +104,18 @@ Deno.serve(async (req) => {
 
   // Check if user is the finder
   if (recovery.finder_id !== user.id) {
-    return new Response(
-      JSON.stringify({ error: 'Only the finder can mark the reward as received' }),
-      {
-        status: 403,
-        headers: { 'Content-Type': 'application/json' },
-      }
-    );
+    return new Response(JSON.stringify({ error: 'Only the finder can mark the reward as received' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
   }
 
   // Check if recovery is in 'recovered' status
   if (recovery.status !== 'recovered') {
-    return new Response(
-      JSON.stringify({ error: 'Reward can only be marked as paid after disc is recovered' }),
-      {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      }
-    );
+    return new Response(JSON.stringify({ error: 'Reward can only be marked as paid after disc is recovered' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
   }
 
   // Check if already marked as paid
@@ -165,13 +159,10 @@ Deno.serve(async (req) => {
 
   if (updateError) {
     console.error('Failed to mark reward as paid:', updateError);
-    return new Response(
-      JSON.stringify({ error: 'Failed to mark reward as received', details: updateError.message }),
-      {
-        status: 500,
-        headers: { 'Content-Type': 'application/json' },
-      }
-    );
+    return new Response(JSON.stringify({ error: 'Failed to mark reward as received', details: updateError.message }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
   }
 
   return new Response(

--- a/supabase/functions/send-reward-payment/index.test.ts
+++ b/supabase/functions/send-reward-payment/index.test.ts
@@ -128,13 +128,10 @@ Deno.test('send-reward-payment: should return 400 when recovery_event_id missing
   const body: { recovery_event_id?: string } = {};
 
   if (!body.recovery_event_id) {
-    const response = new Response(
-      JSON.stringify({ error: 'Missing required field: recovery_event_id' }),
-      {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      }
-    );
+    const response = new Response(JSON.stringify({ error: 'Missing required field: recovery_event_id' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
     assertEquals(response.status, 400);
     const data = await response.json();
     assertEquals(data.error, 'Missing required field: recovery_event_id');
@@ -162,21 +159,14 @@ Deno.test('send-reward-payment: should return 403 when user is not owner', async
   authHeaderPresent = true;
 
   const supabase = mockSupabaseClient();
-  const { data } = await supabase
-    .from('recovery_events')
-    .select('*')
-    .eq('id', 'recovery-123')
-    .single();
+  const { data } = await supabase.from('recovery_events').select('*').eq('id', 'recovery-123').single();
 
   const recovery = data as MockRecoveryEvent | null;
   if (recovery?.disc && recovery.disc.owner_id !== currentUserId) {
-    const response = new Response(
-      JSON.stringify({ error: 'Only the disc owner can send the reward' }),
-      {
-        status: 403,
-        headers: { 'Content-Type': 'application/json' },
-      }
-    );
+    const response = new Response(JSON.stringify({ error: 'Only the disc owner can send the reward' }), {
+      status: 403,
+      headers: { 'Content-Type': 'application/json' },
+    });
     assertEquals(response.status, 403);
   }
 });
@@ -200,21 +190,14 @@ Deno.test('send-reward-payment: should return 400 when recovery not in recovered
   authHeaderPresent = true;
 
   const supabase = mockSupabaseClient();
-  const { data } = await supabase
-    .from('recovery_events')
-    .select('*')
-    .eq('id', 'recovery-123')
-    .single();
+  const { data } = await supabase.from('recovery_events').select('*').eq('id', 'recovery-123').single();
 
   const recovery = data as MockRecoveryEvent | null;
   if (recovery && recovery.status !== 'recovered') {
-    const response = new Response(
-      JSON.stringify({ error: 'Reward can only be sent after disc is recovered' }),
-      {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      }
-    );
+    const response = new Response(JSON.stringify({ error: 'Reward can only be sent after disc is recovered' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
     assertEquals(response.status, 400);
   }
 });
@@ -238,11 +221,7 @@ Deno.test('send-reward-payment: should return 400 when already paid', async () =
   authHeaderPresent = true;
 
   const supabase = mockSupabaseClient();
-  const { data } = await supabase
-    .from('recovery_events')
-    .select('*')
-    .eq('id', 'recovery-123')
-    .single();
+  const { data } = await supabase.from('recovery_events').select('*').eq('id', 'recovery-123').single();
 
   const recovery = data as MockRecoveryEvent | null;
   if (recovery?.reward_paid_at) {

--- a/supabase/functions/send-reward-payment/index.ts
+++ b/supabase/functions/send-reward-payment/index.ts
@@ -136,13 +136,10 @@ Deno.serve(async (req) => {
 
   // Check if recovery is in 'recovered' status
   if (recovery.status !== 'recovered') {
-    return new Response(
-      JSON.stringify({ error: 'Reward can only be sent after disc is recovered' }),
-      {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      }
-    );
+    return new Response(JSON.stringify({ error: 'Reward can only be sent after disc is recovered' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
   }
 
   // Check if already paid


### PR DESCRIPTION
## Summary
- Update stripe-webhook to try both `STRIPE_WEBHOOK_SECRET` and `STRIPE_CONNECT_WEBHOOK_SECRET`
- Stripe Connect webhooks use a different signing secret than main account webhooks
- This allows both webhook endpoints to use the same handler

## Setup Required
After merging, set the `STRIPE_CONNECT_WEBHOOK_SECRET` environment variable in Supabase with the signing secret from your Connected accounts webhook endpoint.

## Test plan
- [x] Type check passes
- [ ] Webhook signature verification works for main account events
- [ ] Webhook signature verification works for Connect account events

🤖 Generated with [Claude Code](https://claude.com/claude-code)