### PR TITLE
perf: deploy only changed edge functions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,18 +93,45 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
         with:
           version: latest
 
-      - name: Deploy edge functions
+      - name: Deploy changed edge functions
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: |
           supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
-          supabase functions deploy --no-verify-jwt
+
+          # Get changed files in supabase/functions/
+          changed_files=$(git diff --name-only HEAD~1 HEAD -- supabase/functions/)
+
+          # If _shared changed, deploy all functions
+          if echo "$changed_files" | grep -q "supabase/functions/_shared/"; then
+            echo "Shared code changed - deploying all functions"
+            supabase functions deploy --no-verify-jwt
+            exit 0
+          fi
+
+          # Get unique function directories that changed
+          changed_functions=$(echo "$changed_files" | grep "supabase/functions/" | cut -d'/' -f3 | sort -u | grep -v "^_shared$" || true)
+
+          if [ -z "$changed_functions" ]; then
+            echo "No function changes detected - skipping deployment"
+            exit 0
+          fi
+
+          echo "Deploying changed functions: $changed_functions"
+          for fn in $changed_functions; do
+            if [ -d "supabase/functions/$fn" ]; then
+              echo "Deploying $fn..."
+              supabase functions deploy "$fn" --no-verify-jwt
+            fi
+          done
 
   release:
     needs: [test, check-edge-functions, migrate, deploy-functions]


### PR DESCRIPTION
## Summary
Instead of deploying all ~50 functions on every push (3+ min), now only deploys functions that have changes.

## Changes
- If `_shared/` changes → deploys all functions (since all depend on it)
- Otherwise → deploys only the specific functions that changed
- If no function changes → skips deployment entirely

## Expected impact
- Single function change: ~5 seconds instead of 3 minutes
- Shared code change: Same as before (deploys all)

🤖 Generated with [Claude Code](https://claude.com/claude-code)