### PR TITLE
fix: pass secrets to reusable test workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    secrets: inherit
 
   check-edge-functions:
     name: Type Check Edge Functions


### PR DESCRIPTION
## Summary
- Add `secrets: inherit` to the test job to pass HEIMDALLR_TOKEN to the shared test.yml workflow
- The shared test.yml was updated on Dec 23rd to require HEIMDALLR_TOKEN for coverage reporting
- This was causing `startup_failure` on all workflow runs, preventing migrations and function deployments

## Root Cause
The shared `discrapp/.github/.github/workflows/test.yml` requires `HEIMDALLR_TOKEN` as a required secret. Without passing it, GitHub can't validate the workflow and fails at startup.

## Test plan
- [ ] Verify workflow passes after merge
- [ ] Verify migrations run on push to main
- [ ] Verify edge functions deploy on push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)