### PR TITLE
fix: parse function names correctly from supabase CLI output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,11 +108,13 @@ jobs:
         run: |
           supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_REF }}
 
-          # Get all deployed functions
-          deployed_functions=$(supabase functions list --project-ref ${{ secrets.SUPABASE_PROJECT_REF }} 2>/dev/null | tail -n +2 | awk '{print $1}' || echo "")
+          # Get all deployed functions (skip 4 header lines, extract SLUG from column 3)
+          deployed_functions=$(supabase functions list --project-ref ${{ secrets.SUPABASE_PROJECT_REF }} 2>/dev/null | tail -n +5 | awk -F'|' '{gsub(/^ +| +$/, "", $3); print $3}' || echo "")
+          echo "Found $(echo "$deployed_functions" | grep -c .) deployed functions"
 
           # Get all local function directories (excluding _shared)
           local_functions=$(ls -d supabase/functions/*/ 2>/dev/null | xargs -I {} basename {} | grep -v "^_shared$" || echo "")
+          echo "Found $(echo "$local_functions" | wc -w | tr -d ' ') local functions"
 
           # Check for new functions that aren't deployed yet
           new_functions=""


### PR DESCRIPTION
## Summary
- Fix the `supabase functions list` output parsing to correctly extract function names
- Add debug logging to show count of deployed vs local functions

## Root Cause
The previous parsing used `awk '{print $1}'` which printed the **UUID** (column 1) instead of the **function slug** (column 3). This caused all functions to appear as "new" because the UUIDs never matched the local directory names.

**Before (broken):**
```bash
tail -n +2 | awk '{print $1}'  # Returns: 86f8ea7c-d92d-4a3c-8a16-b148162c4a5b
```

**After (fixed):**
```bash
tail -n +5 | awk -F'|' '{gsub(/^ +| +$/, "", $3); print $3}'  # Returns: create-disc
```

## Impact
- Previously: ALL 54 functions deployed on every push (~3 min)
- Now: Only changed functions deploy (~3 sec each)

## Test plan
- [ ] Merge to main
- [ ] Verify logs show "Found 54 deployed functions" and "Found 54 local functions"
- [ ] Verify only changed functions (or none) are deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)