### PR TITLE
fix: strengthen basket position rules - must be on fairway

### DIFF
--- a/supabase/functions/get-shot-recommendation/index.ts
+++ b/supabase/functions/get-shot-recommendation/index.ts
@@ -109,10 +109,13 @@ IMPORTANT GUIDELINES:
 FLIGHT PATH VISUALIZATION:
 Estimate the position of the tee box and basket in the image as percentages (0-100):
 - tee_position: Where the photo is taken from (usually bottom center, around x:50, y:85-95)
-- basket_position: Where the basket is ON THE GROUND at the end of the fairway.
-  IMPORTANT: The basket is ALWAYS on the ground, NOT in the sky. Look for where the fairway
-  leads to - typically y:30-60 range (middle of image), never above y:25 (that would be sky/trees).
-  If you can see the basket, use its exact position. If not, estimate where the fairway ends.
+- basket_position: Where the basket is located ON THE FAIRWAY/GROUND.
+  CRITICAL RULES:
+  1. The basket is ALWAYS on grass/ground, NEVER in sky, trees, or water
+  2. Follow the visible fairway/path - the basket is at the END of that path
+  3. Y value should typically be 40-65 (middle-lower portion of image)
+  4. If y is less than 35, you're probably placing it in trees/sky - move it DOWN
+  5. Look for the mowed grass area or walking path - basket is ON that surface
 
 Return ONLY this JSON (no other text):
 {


### PR DESCRIPTION
## Summary
Basket was still being placed on trees instead of the fairway. Strengthened the prompt with critical rules:

1. NEVER in sky, trees, or water  
2. Follow the visible fairway/path
3. Y value should be 40-65 range (lower in image than before)
4. If y < 35, it's probably in trees - move it DOWN
5. Look for mowed grass/walking path

## Test plan
- [ ] Upload hole photo and verify basket is on the grass/fairway, not trees

🤖 Generated with [Claude Code](https://claude.com/claude-code)