### PR TITLE
security: use user JWT instead of service role key for user operations

### DIFF
--- a/supabase/functions/abandon-disc/index.ts
+++ b/supabase/functions/abandon-disc/index.ts
@@ -55,6 +55,7 @@ const handler = async (req: Request): Promise<Response> => {
     });
   }
 
+  // Create Supabase client with user's auth for RLS-protected operations
   const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
   const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
   const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
@@ -78,10 +79,11 @@ const handler = async (req: Request): Promise<Response> => {
     });
   }
 
+  // Service role client only for operations that need to bypass RLS (e.g., notifications to other users)
   const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
 
-  // Get the recovery event with disc info
-  const { data: recovery, error: recoveryError } = await supabaseAdmin
+  // Get the recovery event with disc info (using user's JWT for RLS)
+  const { data: recovery, error: recoveryError } = await supabase
     .from('recovery_events')
     .select(
       `
@@ -130,8 +132,8 @@ const handler = async (req: Request): Promise<Response> => {
     });
   }
 
-  // Update recovery status to abandoned
-  const { error: updateRecoveryError } = await supabaseAdmin
+  // Update recovery status to abandoned (using user's JWT for RLS)
+  const { error: updateRecoveryError } = await supabase
     .from('recovery_events')
     .update({
       status: 'abandoned',
@@ -147,8 +149,8 @@ const handler = async (req: Request): Promise<Response> => {
     });
   }
 
-  // Set disc owner_id to null (making it claimable)
-  const { error: updateDiscError } = await supabaseAdmin
+  // Set disc owner_id to null (making it claimable) using user's JWT for RLS
+  const { error: updateDiscError } = await supabase
     .from('discs')
     .update({
       owner_id: null,

--- a/supabase/functions/accept-meetup/index.ts
+++ b/supabase/functions/accept-meetup/index.ts
@@ -61,7 +61,7 @@ const handler = async (req: Request): Promise<Response> => {
     });
   }
 
-  // Create Supabase client with user's auth
+  // Create Supabase client with user's auth for RLS-protected operations
   const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
   const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
   const supabase = createClient(supabaseUrl, supabaseAnonKey, {
@@ -83,12 +83,12 @@ const handler = async (req: Request): Promise<Response> => {
     });
   }
 
-  // Use service role for database operations
+  // Service role client only for operations that need to bypass RLS (e.g., notifications to other users)
   const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
   const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
 
-  // Get the meetup proposal with recovery event and disc info
-  const { data: proposal, error: proposalError } = await supabaseAdmin
+  // Get the meetup proposal with recovery event and disc info (using user's JWT for RLS)
+  const { data: proposal, error: proposalError } = await supabase
     .from('meetup_proposals')
     .select(
       `
@@ -191,8 +191,8 @@ const handler = async (req: Request): Promise<Response> => {
     });
   }
 
-  // Update the proposal status to accepted
-  const { data: updatedProposal, error: updateError } = await supabaseAdmin
+  // Update the proposal status to accepted (using user's JWT for RLS)
+  const { data: updatedProposal, error: updateError } = await supabase
     .from('meetup_proposals')
     .update({
       status: 'accepted',
@@ -209,8 +209,8 @@ const handler = async (req: Request): Promise<Response> => {
     });
   }
 
-  // Update recovery event status to 'meetup_confirmed'
-  const { error: eventUpdateError } = await supabaseAdmin
+  // Update recovery event status to 'meetup_confirmed' (using user's JWT for RLS)
+  const { error: eventUpdateError } = await supabase
     .from('recovery_events')
     .update({
       status: 'meetup_confirmed',

--- a/supabase/functions/complete-recovery/index.ts
+++ b/supabase/functions/complete-recovery/index.ts
@@ -60,7 +60,7 @@ const handler = async (req: Request): Promise<Response> => {
     });
   }
 
-  // Create Supabase client with user's auth
+  // Create Supabase client with user's auth for RLS-protected operations
   const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
   const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
   const supabase = createClient(supabaseUrl, supabaseAnonKey, {
@@ -82,12 +82,12 @@ const handler = async (req: Request): Promise<Response> => {
     });
   }
 
-  // Use service role for database operations
+  // Service role client only for operations that need to bypass RLS (e.g., notifications to other users)
   const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
   const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
 
-  // Get the recovery event with disc info
-  const { data: recoveryEvent, error: recoveryError } = await supabaseAdmin
+  // Get the recovery event with disc info (using user's JWT for RLS)
+  const { data: recoveryEvent, error: recoveryError } = await supabase
     .from('recovery_events')
     .select(
       `
@@ -143,8 +143,8 @@ const handler = async (req: Request): Promise<Response> => {
     );
   }
 
-  // Update recovery event status to 'recovered'
-  const { data: updatedRecovery, error: updateError } = await supabaseAdmin
+  // Update recovery event status to 'recovered' (using user's JWT for RLS)
+  const { data: updatedRecovery, error: updateError } = await supabase
     .from('recovery_events')
     .update({
       status: 'recovered',

--- a/supabase/functions/decline-meetup/index.ts
+++ b/supabase/functions/decline-meetup/index.ts
@@ -60,7 +60,7 @@ const handler = async (req: Request): Promise<Response> => {
     });
   }
 
-  // Create Supabase client with user's auth
+  // Create Supabase client with user's auth for RLS-protected operations
   const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
   const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
   const supabase = createClient(supabaseUrl, supabaseAnonKey, {
@@ -82,12 +82,12 @@ const handler = async (req: Request): Promise<Response> => {
     });
   }
 
-  // Use service role for database operations
+  // Service role client only for operations that need to bypass RLS (e.g., notifications to other users)
   const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
   const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
 
-  // Get the meetup proposal with recovery event and disc info
-  const { data: proposal, error: proposalError } = await supabaseAdmin
+  // Get the meetup proposal with recovery event and disc info (using user's JWT for RLS)
+  const { data: proposal, error: proposalError } = await supabase
     .from('meetup_proposals')
     .select(
       `
@@ -163,8 +163,8 @@ const handler = async (req: Request): Promise<Response> => {
     });
   }
 
-  // Update the proposal status to declined
-  const { data: updatedProposal, error: updateError } = await supabaseAdmin
+  // Update the proposal status to declined (using user's JWT for RLS)
+  const { data: updatedProposal, error: updateError } = await supabase
     .from('meetup_proposals')
     .update({
       status: 'declined',
@@ -181,8 +181,8 @@ const handler = async (req: Request): Promise<Response> => {
     });
   }
 
-  // Update recovery event status back to 'found' so another proposal can be made
-  const { error: eventUpdateError } = await supabaseAdmin
+  // Update recovery event status back to 'found' so another proposal can be made (using user's JWT for RLS)
+  const { error: eventUpdateError } = await supabase
     .from('recovery_events')
     .update({
       status: 'found',

--- a/supabase/functions/mark-disc-retrieved/index.ts
+++ b/supabase/functions/mark-disc-retrieved/index.ts
@@ -60,7 +60,7 @@ const handler = async (req: Request): Promise<Response> => {
     });
   }
 
-  // Create Supabase client with user's auth
+  // Create Supabase client with user's auth for RLS-protected operations
   const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
   const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
   const supabase = createClient(supabaseUrl, supabaseAnonKey, {
@@ -82,12 +82,12 @@ const handler = async (req: Request): Promise<Response> => {
     });
   }
 
-  // Use service role for database operations
+  // Service role client only for operations that need to bypass RLS (e.g., notifications to other users)
   const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
   const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
 
-  // Get the recovery event with disc and drop-off info
-  const { data: recoveryEvent, error: recoveryError } = await supabaseAdmin
+  // Get the recovery event with disc and drop-off info (using user's JWT for RLS)
+  const { data: recoveryEvent, error: recoveryError } = await supabase
     .from('recovery_events')
     .select(
       `
@@ -131,8 +131,8 @@ const handler = async (req: Request): Promise<Response> => {
     });
   }
 
-  // Update the drop-off record with retrieved_at timestamp
-  const { error: dropOffError } = await supabaseAdmin
+  // Update the drop-off record with retrieved_at timestamp (using user's JWT for RLS)
+  const { error: dropOffError } = await supabase
     .from('drop_offs')
     .update({ retrieved_at: new Date().toISOString() })
     .eq('recovery_event_id', recovery_event_id);
@@ -145,8 +145,8 @@ const handler = async (req: Request): Promise<Response> => {
     });
   }
 
-  // Update recovery event status to 'recovered'
-  const { error: updateError } = await supabaseAdmin
+  // Update recovery event status to 'recovered' (using user's JWT for RLS)
+  const { error: updateError } = await supabase
     .from('recovery_events')
     .update({ status: 'recovered', updated_at: new Date().toISOString() })
     .eq('id', recovery_event_id);

--- a/supabase/functions/mark-reward-paid/index.ts
+++ b/supabase/functions/mark-reward-paid/index.ts
@@ -53,6 +53,7 @@ const handler = async (req: Request): Promise<Response> => {
     });
   }
 
+  // Create Supabase client with user's auth for RLS-protected operations
   const supabaseUrl = Deno.env.get('SUPABASE_URL') ?? '';
   const supabaseKey = Deno.env.get('SUPABASE_ANON_KEY') ?? '';
   const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '';
@@ -76,10 +77,11 @@ const handler = async (req: Request): Promise<Response> => {
     });
   }
 
-  const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
+  // Service role client only for operations that need to bypass RLS (not used in this function currently)
+  const _supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
 
-  // Get recovery event with disc info
-  const { data: recovery, error: recoveryError } = await supabaseAdmin
+  // Get recovery event with disc info (using user's JWT for RLS)
+  const { data: recovery, error: recoveryError } = await supabase
     .from('recovery_events')
     .select(
       `
@@ -148,9 +150,9 @@ const handler = async (req: Request): Promise<Response> => {
     });
   }
 
-  // Mark reward as paid
+  // Mark reward as paid (using user's JWT for RLS)
   const now = new Date().toISOString();
-  const { error: updateError } = await supabaseAdmin
+  const { error: updateError } = await supabase
     .from('recovery_events')
     .update({
       reward_paid_at: now,


### PR DESCRIPTION
## Summary
- Changed 12 edge functions to use the user's JWT token for RLS-protected database operations instead of the service role key
- This ensures Row Level Security policies are enforced for user-initiated operations
- Service role is still used only for operations that need to bypass RLS (e.g., sending notifications to other users)

### Functions updated:
- abandon-disc
- accept-meetup
- claim-disc
- complete-recovery
- create-drop-off
- decline-meetup
- mark-disc-retrieved
- mark-reward-paid
- propose-meetup
- relinquish-disc
- report-found-disc
- surrender-disc

## Test plan
- [ ] Verify each function still works correctly with the user's JWT
- [ ] Confirm RLS policies are properly enforced for database operations
- [ ] Test that notifications to other users still work (using service role)

🤖 Generated with [Claude Code](https://claude.com/claude-code)