### PR TITLE
fix: add missing captureException() calls in error paths

### DIFF
--- a/supabase/functions/abandon-disc/index.ts
+++ b/supabase/functions/abandon-disc/index.ts
@@ -2,6 +2,7 @@ import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { sendPushNotification } from '../_shared/push-notifications.ts';
 import { withSentry } from '../_shared/with-sentry.ts';
+import { setUser, captureException } from '../_shared/sentry.ts';
 import { abandonDiscTransaction } from '../_shared/transactions.ts';
 
 /**
@@ -80,6 +81,9 @@ const handler = async (req: Request): Promise<Response> => {
     });
   }
 
+  // Set Sentry user context
+  setUser(user.id);
+
   // Service role client only for operations that need to bypass RLS (e.g., notifications to other users)
   const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
 
@@ -143,6 +147,12 @@ const handler = async (req: Request): Promise<Response> => {
 
   if (!transactionResult.success) {
     console.error('Failed to abandon disc:', transactionResult.error);
+    captureException(new Error(transactionResult.error), {
+      operation: 'abandon-disc',
+      recoveryEventId: recovery_event_id,
+      discId: disc.id,
+      userId: user.id,
+    });
     return new Response(JSON.stringify({ error: 'Failed to abandon disc', details: transactionResult.error }), {
       status: 500,
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary

- Added `captureException()` calls to database error paths in 4 disc management functions
- Added `setUser()` context setting after authentication in each function
- Added TDD-style tests for the error capture behavior

### Functions updated:
- `create-disc`: Captures exception on insert failure with `operation`, `userId`
- `delete-disc`: Captures exception on delete failure with `operation`, `discId`, `userId`
- `update-disc`: Captures exception on update failure with `operation`, `discId`, `userId`
- `abandon-disc`: Captures exception on transaction failure with `operation`, `recoveryEventId`, `discId`, `userId`

### Note
This is a focused fix for the most critical disc management functions. The full audit identified many more error paths that could benefit from Sentry error capture - those can be addressed in follow-up PRs.

Fixes #223

## Test plan
- [x] All 756 tests pass with `deno test --allow-all`
- [x] Type checking passes with `deno check`
- [x] New tests verify captureException is called with appropriate context on error paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)