### PR TITLE
fix: allow owner_id to be NULL for abandoned discs

### DIFF
--- a/supabase/migrations/20260101_fix_owner_id_nullable.sql
+++ b/supabase/migrations/20260101_fix_owner_id_nullable.sql
@@ -1,0 +1,9 @@
+-- Fix: Allow owner_id to be NULL for abandoned discs
+-- Issue #235: When a disc is abandoned, the owner_id should be set to NULL
+-- to indicate that the disc no longer has an owner and can be claimed
+
+-- Drop NOT NULL constraint from owner_id column
+ALTER TABLE "public"."discs" ALTER COLUMN "owner_id" DROP NOT NULL;
+
+-- Add comment explaining the nullable owner_id
+COMMENT ON COLUMN "public"."discs"."owner_id" IS 'Owner of the disc. NULL indicates an abandoned disc that can be claimed.';


### PR DESCRIPTION
## Summary

- Adds migration to drop NOT NULL constraint from `discs.owner_id` column
- Allows abandoned discs to have a NULL owner, indicating they can be claimed by anyone

Fixes #235

## Test plan

- [ ] Apply migration to local database
- [ ] Verify `owner_id` column accepts NULL values
- [ ] Verify existing discs with owner_id are unaffected
- [ ] Verify abandoned discs can have owner_id set to NULL

🤖 Generated with [Claude Code](https://claude.com/claude-code)