### PR TITLE
fix: use namespace imports for qrcode and exifreader esm modules

### DIFF
--- a/supabase/functions/generate-sticker-pdf/index.ts
+++ b/supabase/functions/generate-sticker-pdf/index.ts
@@ -1,7 +1,7 @@
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { PDFDocument, rgb, StandardFonts } from 'https://esm.sh/pdf-lib@1.17.1';
-import QRCode from 'https://esm.sh/qrcode@1.5.3';
+import * as QRCode from 'https://esm.sh/qrcode@1.5.3';
 import { LOGO_BASE64 } from './logo-data.ts';
 import { withSentry } from '../_shared/with-sentry.ts';
 

--- a/supabase/functions/get-shot-recommendation/index.ts
+++ b/supabase/functions/get-shot-recommendation/index.ts
@@ -1,7 +1,7 @@
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { encodeBase64 } from 'https://deno.land/std@0.224.0/encoding/base64.ts';
-import ExifReader from 'https://esm.sh/exifreader@4.14.1';
+import * as ExifReader from 'https://esm.sh/exifreader@4.14.1';
 import { withSentry } from '../_shared/with-sentry.ts';
 import { setUser, captureException } from '../_shared/sentry.ts';
 


### PR DESCRIPTION
## Summary

- `import QRCode from '...'` → `import * as QRCode from '...'` in `generate-sticker-pdf`
- `import ExifReader from '...'` → `import * as ExifReader from '...'` in `get-shot-recommendation`

Both esm.sh modules lack a default export in their type definitions, causing TS2613 errors. Namespace imports preserve the existing call-site usage (`QRCode.toDataURL(...)`, `ExifReader.load(...)`).

Fixes the type check failures blocking Renovate PR #292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)