### PR TITLE
chore: inherit renovate config from discrapp/.github

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,41 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "timezone": "America/Denver",
-  "schedule": ["after 10pm every weekday", "before 5am every weekday", "every weekend"],
-  "dependencyDashboard": true,
-  "dependencyDashboardTitle": "Renovate Dependency Dashboard",
-  "semanticCommits": "enabled",
-  "commitMessagePrefix": "chore(deps):",
-  "commitMessageAction": "update",
-  "commitMessageExtra": "to {{newValue}}",
-  "commitMessageTopic": "{{depName}}",
-  "automerge": false,
-  "platformAutomerge": false,
-  "rebaseWhen": "behind-base-branch",
-  "labels": ["dependencies", "renovate"],
-  "assignees": ["@benniemosher"],
-  "vulnerabilityAlerts": {
-    "labels": ["security", "dependencies"],
-    "assignees": ["@benniemosher"]
-  },
+  "extends": ["github>discrapp/.github"],
   "packageRules": [
     {
       "description": "Group Supabase packages",
       "groupName": "supabase packages",
       "matchPackageNames": ["/^@supabase//"]
-    },
-    {
-      "description": "GitHub Actions - automerge patch/minor",
-      "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true,
-      "automergeType": "pr"
-    },
-    {
-      "description": "Pre-commit hooks - group updates",
-      "matchManagers": ["pre-commit"],
-      "groupName": "pre-commit hooks"
     },
     {
       "description": "Deno dependencies - group together",


### PR DESCRIPTION
## Summary

- Extend shared `github>discrapp/.github` Renovate preset
- Removes duplicated org-wide config (schedule, labels, commit messages, automerge settings)
- Keeps only api-specific grouping rules (Supabase, Deno)

Depends on discrapp/.github#16 being merged first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)