### PR TITLE
chore: keep Supabase project from pausing

### DIFF
--- a/.github/workflows/keep-supabase-alive.yml
+++ b/.github/workflows/keep-supabase-alive.yml
@@ -5,6 +5,8 @@ on:
     - cron: '0 12 * * 1,4' # Mon/Thu at noon UTC
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   ping:
     runs-on: ubuntu-latest

--- a/.github/workflows/keep-supabase-alive.yml
+++ b/.github/workflows/keep-supabase-alive.yml
@@ -1,0 +1,15 @@
+name: Keep Supabase alive
+
+on:
+  schedule:
+    - cron: '0 12 * * 1,4' # Mon/Thu at noon UTC
+  workflow_dispatch:
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Supabase REST API
+        run: |
+          curl -sf "${{ secrets.SUPABASE_URL }}/rest/v1/" \
+            -H "apikey: ${{ secrets.SUPABASE_ANON_KEY }}" || true


### PR DESCRIPTION
## Summary

- Adds a scheduled GitHub Actions workflow that pings the Supabase REST API twice a week (Mon/Thu)
- Reuses existing `SUPABASE_URL` and `SUPABASE_ANON_KEY` repo secrets
- Includes `workflow_dispatch` so it can be triggered manually to unfreeze the project immediately

## Test plan

- [ ] Verify workflow appears in Actions tab after merge
- [ ] Run manually via workflow_dispatch to confirm the ping succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)