### PR TITLE
fix: use local Biome pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,11 +33,14 @@ repos:
     rev: 3.2.495
     hooks:
       - id: checkov_container
-  - repo: https://github.com/biomejs/pre-commit
-    rev: "v2.5.4"
+  - repo: local
     hooks:
       - id: biome-check
-        additional_dependencies: ["@biomejs/biome@2.5.4"]
+        name: Biome Check
+        language: system
+        entry: ./node_modules/.bin/biome
+        args: [check, .]
+        pass_filenames: false
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v4.3.0
     hooks:


### PR DESCRIPTION
## Summary

- The `biomejs/pre-commit` external hook at `v2.5.4` no longer has a `package.json` at the location pre-commit expects, causing `AssertionError` during hook install
- Switches to a local hook that calls `./node_modules/.bin/biome` directly — no nodeenv or external download needed, uses the Biome binary already installed as a dev dependency

## Test plan

- [ ] pre-commit hooks pass locally
- [ ] CI pre-commit check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)